### PR TITLE
Audit quick fixes: F-05 module names, F-01 async defs, F-12 multi-seed traversal

### DIFF
--- a/ingestion_service/src/core/extractors/python_extractor.py
+++ b/ingestion_service/src/core/extractors/python_extractor.py
@@ -30,7 +30,14 @@ from typing import List, Dict, Optional
 class PythonASTExtractor(ast.NodeVisitor):
     def __init__(self, relative_path: str):
         self.relative_path = relative_path
-        self.module_name = relative_path.replace("/", ".").rstrip(".py")
+        # F-05: strip the ".py" suffix, not the character set {., p, y} —
+        # rstrip(".py") corrupted names like "happy.py" → "ha".
+        module_path = (
+            relative_path[:-3]
+            if relative_path.endswith(".py")
+            else relative_path
+        )
+        self.module_name = module_path.replace("/", ".")
         self.module_id = relative_path  # canonical module id
         self.artifacts: List[Dict] = []
         self.scope_stack: List[str] = []  # maintains current lexical scope
@@ -110,6 +117,7 @@ class PythonASTExtractor(ast.NodeVisitor):
                 "lineno": node.lineno,
                 "col_offset": node.col_offset,
                 "args": [arg.arg for arg in node.args.args],
+                "is_async": isinstance(node, ast.AsyncFunctionDef),
             },
         }
 
@@ -119,6 +127,11 @@ class PythonASTExtractor(ast.NodeVisitor):
         self.scope_stack.append(canonical_id)
         self.generic_visit(node)
         self.scope_stack.pop()
+
+    # F-01: async defs must produce FUNCTION/METHOD artifacts too —
+    # without this alias every `async def` was invisible to the graph
+    # and calls inside it were mis-attributed to the enclosing scope.
+    visit_AsyncFunctionDef = visit_FunctionDef
 
     def visit_Import(self, node: ast.Import):
         for alias in node.names:

--- a/ingestion_service/tests/codebase/test_extractor_fixes.py
+++ b/ingestion_service/tests/codebase/test_extractor_fixes.py
@@ -1,0 +1,131 @@
+# ingestion_service/tests/codebase/test_extractor_fixes.py
+"""
+F-05: module names must strip the ".py" suffix, not the {., p, y} char set.
+F-01: async defs must produce FUNCTION/METHOD artifacts like sync defs.
+"""
+import pytest
+from uuid import uuid4
+
+from src.core.codebase.repo_graph_builder import RepoGraphBuilder
+from src.core.extractors.python_extractor import PythonASTExtractor
+
+pytestmark = pytest.mark.unit
+
+
+# -----------------------------
+# F-05 — module naming
+# -----------------------------
+
+@pytest.mark.parametrize(
+    "relative_path, expected_module_name",
+    [
+        ("happy.py", "happy"),                 # was "ha"
+        ("utils/copy.py", "utils.copy"),       # was "utils.co"
+        ("spy.py", "spy"),                     # was "s"
+        ("pkg/sub/mod.py", "pkg.sub.mod"),
+        ("app/service.py", "app.service"),
+        ("proxy.py", "proxy"),                 # was "prox"
+    ],
+)
+def test_module_name_strips_suffix_not_charset(
+    relative_path, expected_module_name
+):
+    extractor = PythonASTExtractor(relative_path=relative_path)
+    assert extractor.module_name == expected_module_name
+
+
+def test_module_artifact_carries_fixed_name():
+    artifacts = PythonASTExtractor(relative_path="happy.py").extract("x = 1\n")
+    module = next(a for a in artifacts if a["artifact_type"] == "MODULE")
+    assert module["name"] == "happy"
+    assert module["id"] == "happy.py"  # canonical id unchanged (ADR-031)
+
+
+# -----------------------------
+# F-01 — async defs
+# -----------------------------
+
+ASYNC_SOURCE = (
+    "class Handler:\n"
+    "    async def handle(self):\n"
+    "        return await self.load()\n"
+    "\n"
+    "    def load(self):\n"
+    "        return 1\n"
+    "\n"
+    "\n"
+    "async def main():\n"
+    "    helper()\n"
+    "\n"
+    "\n"
+    "def helper():\n"
+    "    return 2\n"
+)
+
+
+@pytest.fixture()
+def async_artifacts():
+    return PythonASTExtractor(relative_path="app.py").extract(ASYNC_SOURCE)
+
+
+def test_async_function_produces_artifact(async_artifacts):
+    funcs = {
+        a["id"]: a for a in async_artifacts
+        if a["artifact_type"] in ("FUNCTION", "METHOD")
+    }
+    assert "app.py#main" in funcs, "async def main is invisible (F-01)"
+    assert funcs["app.py#main"]["artifact_type"] == "FUNCTION"
+    assert funcs["app.py#main"]["metadata"]["is_async"] is True
+
+
+def test_async_method_produces_method_artifact(async_artifacts):
+    funcs = {
+        a["id"]: a for a in async_artifacts
+        if a["artifact_type"] in ("FUNCTION", "METHOD")
+    }
+    assert "app.py#Handler.handle" in funcs
+    assert funcs["app.py#Handler.handle"]["artifact_type"] == "METHOD"
+    assert funcs["app.py#Handler.handle"]["metadata"]["is_async"] is True
+
+
+def test_sync_defs_marked_not_async(async_artifacts):
+    funcs = {
+        a["id"]: a for a in async_artifacts
+        if a["artifact_type"] in ("FUNCTION", "METHOD")
+    }
+    assert funcs["app.py#helper"]["metadata"]["is_async"] is False
+    assert funcs["app.py#Handler.load"]["metadata"]["is_async"] is False
+
+
+def test_calls_inside_async_body_attributed_to_async_def(async_artifacts):
+    """Before F-01 the CALL inside `async def main` had the MODULE as its
+    parent — mis-attributing the caller."""
+    calls = {
+        a["name"]: a for a in async_artifacts
+        if a["artifact_type"] == "CALL"
+    }
+    assert calls["helper"]["parent_id"] == "app.py#main"
+    assert calls["self.load"]["parent_id"] == "app.py#Handler.handle"
+
+
+def test_async_def_end_to_end_through_graph_builder(tmp_path):
+    """Async artifacts must flow through the full build: entity present,
+    text extracted from the `async def` line, DEFINES edge created."""
+    (tmp_path / "app.py").write_text(ASYNC_SOURCE, encoding="utf-8")
+    graph = RepoGraphBuilder(tmp_path, ingestion_id=str(uuid4())).build()
+
+    entity = graph.entities.get("app.py#main")
+    assert entity is not None
+    assert entity["text"].startswith("async def main():")
+
+    method = graph.entities.get("app.py#Handler.handle")
+    assert method is not None
+    assert method["text"].startswith("async def handle(self):")
+
+    defines = {
+        (r["from_canonical_id"], r["to_canonical_id"])
+        for r in graph.relationships
+        if r["relation_type"] == "DEFINES"
+    }
+    assert ("app.py", "app.py#main") in defines
+    assert ("app.py#Handler", "app.py#Handler.handle") in defines

--- a/rag_orchestrator/pytest.ini
+++ b/rag_orchestrator/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+minversion = 8.0
+testpaths = tests
+pythonpath = .
+
+addopts = -ra
+
+markers =
+    unit: pure unit tests (no DB, no Docker)
+    docker: requires dockerized services (postgres, pgvector)
+    integration: integration tests requiring postgres + pgvector

--- a/rag_orchestrator/src/core/service.py
+++ b/rag_orchestrator/src/core/service.py
@@ -20,7 +20,7 @@ from rag_orchestrator.src.retrieval.types import RetrievedChunk
 from rag_orchestrator.src.retrieval.codebase_utils import extract_canonical_ids_from_chunks
 from rag_orchestrator.src.retrieval.traversal_selector import (
     select_traversal_strategies,
-    execute_traversals,
+    execute_traversals_from_seeds,
 )
 from rag_orchestrator.src.retrieval.codebase_queries import CodebaseGraph, Node
 
@@ -169,9 +169,11 @@ async def hybrid_retrieve(
         from rag_orchestrator.src.retrieval.codebase_utils import get_cached_graph
 
         graph: CodebaseGraph = get_cached_graph(repo_id)
-        start_cid = max(seed_canonical_ids, key=len)
         strategies = select_traversal_strategies(query, seed_canonical_ids)
-        expanded_nodes: List[Node] = execute_traversals(graph, start_cid, strategies)
+        # F-12: expand from every seed, not just the longest-named one
+        expanded_nodes: List[Node] = execute_traversals_from_seeds(
+            graph, seed_canonical_ids, strategies
+        )
         expanded_canonical_ids = {node.canonical_id for node in expanded_nodes}
 
     all_canonical_ids = seed_canonical_ids | expanded_canonical_ids

--- a/rag_orchestrator/src/retrieval/traversal_selector.py
+++ b/rag_orchestrator/src/retrieval/traversal_selector.py
@@ -7,9 +7,9 @@ from functools import partial
 import logging
 
 from .codebase_queries import (
-    traverse_defines, 
-    traverse_calls, 
-    traverse_incoming_calls, 
+    traverse_defines,
+    traverse_calls,
+    traverse_incoming_calls,
     traverse_incoming_imports,
     CodebaseGraph,
     Node
@@ -18,7 +18,7 @@ from .codebase_queries import (
 logger = logging.getLogger(__name__)
 
 def select_traversal_strategies(
-    query: str, 
+    query: str,
     seed_canonical_ids: Set[str]
 ) -> List[Callable[[CodebaseGraph, str], List[Node]]]:
     """
@@ -30,27 +30,27 @@ def select_traversal_strategies(
     """
     query_lower = query.lower()
     strategies = []
-    
+
     # PRIORITY 1: "methods/functions/classes in X"
     if any(term in query_lower for term in ["method", "methods", "function", "functions", "class", "classes", "in"]):
         logger.debug("Selected: traverse_defines (methods/functions in X)")
         strategies.append(partial(traverse_defines, depth=1))
-    
+
     # PRIORITY 2: "what calls X", "callers of X", "called by X"
     elif any(term in query_lower for term in ["callers", "calls", "called by", "who calls"]):
         logger.debug("Selected: traverse_incoming_calls (callers)")
         strategies.append(partial(traverse_incoming_calls, depth=1))
-    
+
     # PRIORITY 3: "what does X call"
     elif any(term in query_lower for term in ["calls", "call"]):
         logger.debug("Selected: traverse_calls (outgoing calls)")
         strategies.append(partial(traverse_calls, depth=1))
-    
+
     # PRIORITY 4: "imports X"
     elif "import" in query_lower:
         logger.debug("Selected: traverse_incoming_imports (imports)")
         strategies.append(partial(traverse_incoming_imports, depth=1))
-    
+
     # DEFAULT: Comprehensive exploration
     else:
         logger.debug("Selected: default (defines + calls)")
@@ -58,20 +58,20 @@ def select_traversal_strategies(
             partial(traverse_defines, depth=1),
             partial(traverse_calls, depth=1)
         ])
-    
+
     logger.info(f"Selected {len(strategies)} traversal strategies for query: '{query[:50]}...'")
     return strategies
 
 def execute_traversals(
-    graph: CodebaseGraph, 
-    start_canonical_id: str, 
+    graph: CodebaseGraph,
+    start_canonical_id: str,
     strategies: List[Callable[[CodebaseGraph, str], List[Node]]]
 ) -> List[Node]:
     """
     Execute all selected traversal strategies.
     """
     all_expanded_nodes = []
-    
+
     for strategy in strategies:
         try:
             nodes = strategy(graph, start_canonical_id)
@@ -80,8 +80,32 @@ def execute_traversals(
         except Exception as e:
             logger.warning(f"Traversal strategy failed: {e}")
             continue
-    
+
     # Deduplicate by canonical_id
     unique_nodes = {node.canonical_id: node for node in all_expanded_nodes}.values()
     logger.info(f"Total unique expanded nodes: {len(unique_nodes)}")
+    return list(unique_nodes)
+
+def execute_traversals_from_seeds(
+    graph: CodebaseGraph,
+    seed_canonical_ids: Set[str],
+    strategies: List[Callable[[CodebaseGraph, str], List[Node]]]
+) -> List[Node]:
+    """
+    F-12: expand from ALL seed canonical_ids, not one arbitrary seed.
+
+    Previously only the longest seed string was traversed and every other
+    vector-search hit was silently dropped from graph expansion. Seeds are
+    bounded by vector-search top_k, so this stays cheap. Iteration is
+    sorted for deterministic results; nodes are deduplicated across seeds.
+    """
+    all_nodes: List[Node] = []
+    for start_cid in sorted(seed_canonical_ids):
+        all_nodes.extend(execute_traversals(graph, start_cid, strategies))
+
+    unique_nodes = {node.canonical_id: node for node in all_nodes}.values()
+    logger.info(
+        f"Multi-seed expansion: {len(seed_canonical_ids)} seeds → "
+        f"{len(unique_nodes)} unique nodes"
+    )
     return list(unique_nodes)

--- a/rag_orchestrator/tests/test_multi_seed_traversal.py
+++ b/rag_orchestrator/tests/test_multi_seed_traversal.py
@@ -1,0 +1,87 @@
+# rag_orchestrator/tests/test_multi_seed_traversal.py
+"""
+F-12: graph expansion must traverse from ALL seed canonical_ids.
+
+Before the fix, only the longest seed string was expanded
+(`max(seed_canonical_ids, key=len)`) and every other vector-search hit
+was silently dropped from graph expansion.
+"""
+from dataclasses import dataclass
+
+import pytest
+
+from src.retrieval.traversal_selector import execute_traversals_from_seeds
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass(frozen=True)
+class FakeNode:
+    canonical_id: str
+
+
+def children_of(graph, start_cid):
+    """Stub strategy: each seed expands to one child node."""
+    return [FakeNode(canonical_id=f"{start_cid}:child")]
+
+
+def test_all_seeds_are_expanded():
+    seeds = {"a.py#f", "lib/very_long_name.py#Klass.method", "b.py#g"}
+
+    nodes = execute_traversals_from_seeds(
+        graph=None, seed_canonical_ids=seeds, strategies=[children_of]
+    )
+
+    expanded = {n.canonical_id for n in nodes}
+    # the old single-seed behavior would only contain the longest seed's child
+    assert expanded == {
+        "a.py#f:child",
+        "lib/very_long_name.py#Klass.method:child",
+        "b.py#g:child",
+    }
+
+
+def test_nodes_deduplicated_across_seeds():
+    def same_child(graph, start_cid):
+        return [FakeNode(canonical_id="shared:node")]
+
+    nodes = execute_traversals_from_seeds(
+        graph=None,
+        seed_canonical_ids={"a.py#f", "b.py#g"},
+        strategies=[same_child],
+    )
+    assert [n.canonical_id for n in nodes] == ["shared:node"]
+
+
+def test_seed_iteration_is_deterministic():
+    seeds = {"z.py#f", "a.py#f", "m.py#f"}
+    calls = []
+
+    def recording(graph, start_cid):
+        calls.append(start_cid)
+        return []
+
+    execute_traversals_from_seeds(
+        graph=None, seed_canonical_ids=seeds, strategies=[recording]
+    )
+    assert calls == sorted(seeds)
+
+
+def test_failing_strategy_does_not_abort_other_seeds():
+    def flaky(graph, start_cid):
+        if start_cid == "bad.py#f":
+            raise RuntimeError("boom")
+        return [FakeNode(canonical_id=f"{start_cid}:child")]
+
+    nodes = execute_traversals_from_seeds(
+        graph=None,
+        seed_canonical_ids={"bad.py#f", "good.py#f"},
+        strategies=[flaky],
+    )
+    assert {n.canonical_id for n in nodes} == {"good.py#f:child"}
+
+
+def test_no_seeds_returns_empty():
+    assert execute_traversals_from_seeds(
+        graph=None, seed_canonical_ids=set(), strategies=[children_of]
+    ) == []


### PR DESCRIPTION
Three small, high-leverage correctness fixes from the July 9 audit (DOCS/audit/01-Codebase-Audit-Findings.md), suggested fix-order step 1:

- **F-05**: `rstrip(".py")` strips a character *set*, corrupting module names for any path ending in p/y/. (`happy.py` → `ha`, `utils/copy.py` → `utils.co`). Now strips the suffix. Canonical IDs unaffected.
- **F-01**: `async def` functions/methods now produce FUNCTION/METHOD artifacts (`visit_AsyncFunctionDef = visit_FunctionDef` + `is_async` metadata). Previously every async handler was invisible to the graph and its calls were mis-attributed to the enclosing scope.
- **F-12**: hybrid retrieval graph expansion traversed from one arbitrary seed (`max(seeds, key=len)`), silently dropping all other vector hits. New `execute_traversals_from_seeds()` expands every seed (sorted, deduplicated).

**Tests**: 17 new unit tests, all passing with no DB/Docker. Also adds `rag_orchestrator/pytest.ini` (the service had no pytest config; its pre-existing test files sit unrunnable inside a directory literally named `tests/__init__.py/` — untouched here, worth a cleanup pass later).

No changes to canonical identity, APIs, persistence, or deployment.