### PR TITLE
Audit remediation: F-03/F-02/F-04 call & import resolution rework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,68 @@
+# ============================================================================
+# rag-foundry-universal — environment template
+#
+# Copy to `.env` (git-ignored) at the repo root. docker-compose.yml loads it
+# via `env_file: ./.env` for ingestion_service, vector_store_service,
+# llm_service, and rag_orchestrator.
+#
+# Note: DATABASE_URL is deliberately NOT set here for the Docker stack —
+# docker-compose.yml injects it directly into ingestion_service and
+# vector_store_service (postgres:5432/ingestion_db). Only set it below when
+# running services/alembic/tests outside Docker.
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Embeddings — used by ingestion_service, vector_store_service, rag_orchestrator
+# ----------------------------------------------------------------------------
+# Embedder backend: "ollama" (real embeddings) or "mock" (tests/dev without Ollama)
+EMBEDDING_PROVIDER=ollama
+# Ollama endpoint as seen from inside containers (host.docker.internal = host machine)
+OLLAMA_BASE_URL=http://host.docker.internal:11434
+# Embedding model — must be pre-pulled in Ollama; mxbai-embed-large produces 1024-dim vectors
+OLLAMA_EMBED_MODEL=mxbai-embed-large:latest
+# Number of texts sent per embedding batch request
+OLLAMA_BATCH_SIZE=50
+# Vector dimension — must match OLLAMA_EMBED_MODEL output and the pgvector schema
+VECTOR_DIMENSION=1024
+
+# ----------------------------------------------------------------------------
+# LLM generation — used by llm_service
+# ----------------------------------------------------------------------------
+# Generation backend (currently only "ollama" is implemented)
+LLM_PROVIDER=ollama
+# Chat/generation model — must be pre-pulled in Ollama
+OLLAMA_MODEL=phi4-mini:latest
+
+# ----------------------------------------------------------------------------
+# Document ingestion options — used by ingestion_service
+# ----------------------------------------------------------------------------
+# Use Docling for PDF parsing; set to false to fall back to PyMuPDF
+#DOCLING_ENABLED=true
+# OCR backend for scanned documents (default: tesseract)
+#OCR_PROVIDER=tesseract
+
+# ----------------------------------------------------------------------------
+# Database — only needed when running OUTSIDE Docker (alembic, local pytest)
+# ----------------------------------------------------------------------------
+# Main DB from the host:
+#DATABASE_URL=postgresql://ingestion_user:ingestion_pass@localhost:5432/ingestion_db
+# Test DB (docker-compose.test.yml, port 5433) — see .env.test:
+#DATABASE_URL=postgresql://ingestion_user:ingestion_pass@localhost:5433/ingestion_test
+
+# ----------------------------------------------------------------------------
+# Service URLs — Docker-network defaults are baked into the code
+# (shared/config/service_urls.py and each service's core/config.py).
+# Override only when running services outside the compose network.
+# ----------------------------------------------------------------------------
+#INGESTION_SERVICE_URL=http://ingestion_service:8000
+#VECTOR_STORE_URL=http://vector_store_service:8002
+#VECTOR_STORE_SERVICE_URL=http://vector_store_service:8002
+#LLM_SERVICE_URL=http://llm_service:8000
+#RAG_ORCHESTRATOR_URL=http://rag_orchestrator:8000
+
+# ----------------------------------------------------------------------------
+# Gradio UI — set by docker-compose.yml for the container; override for a
+# locally-run UI hitting the published host ports.
+# ----------------------------------------------------------------------------
+#API_BASE_URL=http://localhost:8001
+#RAG_API_BASE_URL=http://localhost:8004

--- a/ingestion_service/src/core/codebase/repo_graph.py
+++ b/ingestion_service/src/core/codebase/repo_graph.py
@@ -35,6 +35,9 @@ class RepoGraph:
         self.entities_by_id: Dict[str, dict] = {}
         self.files: Dict[str, List[str]] = {}  # relative_path -> [canonical_id]
         self.relationships: List[dict] = []
+        # F-03: call-site evidence records from the extractor — never
+        # entities, never persisted as nodes. Consumed by _resolve_calls.
+        self.call_sites: List[dict] = []
 
     def add_entity(self, relative_path: str, entity: dict):
         """

--- a/ingestion_service/src/core/codebase/repo_graph.py
+++ b/ingestion_service/src/core/codebase/repo_graph.py
@@ -38,6 +38,10 @@ class RepoGraph:
         # F-03: call-site evidence records from the extractor — never
         # entities, never persisted as nodes. Consumed by _resolve_calls.
         self.call_sites: List[dict] = []
+        # F-02: per-file import bindings (local name -> resolved target),
+        # built by _resolve_imports. In-memory only; consumed by call
+        # resolution (ADR-032 layer 2).
+        self.import_bindings: Dict[str, dict] = {}
 
     def add_entity(self, relative_path: str, entity: dict):
         """

--- a/ingestion_service/src/core/codebase/repo_graph_builder.py
+++ b/ingestion_service/src/core/codebase/repo_graph_builder.py
@@ -134,6 +134,9 @@ class RepoGraphBuilder:
 
                 graph.add_entity(relative_path, artifact)
 
+            # F-03: call sites travel outside the artifact list.
+            graph.call_sites.extend(getattr(extractor, "call_sites", []))
+
         symbol_table = build_symbol_table(graph)
         self._attach_defines(graph)
         self._resolve_calls(graph, symbol_table)
@@ -177,9 +180,18 @@ class RepoGraphBuilder:
     # -----------------------------
 
     def _resolve_calls(self, graph: RepoGraph, symbol_table):
+        """F-03 (WP-G3): consume call-site evidence records and emit one
+        aggregated CALL edge per caller→callee pair. Multiple sites of the
+        same pair land in metadata (call_sites linenos + count) instead of
+        colliding on a shared canonical id."""
+        # (from_cid, to_cid) -> {"linenos": [...], "confidence": float}
+        edges: dict = {}
 
-        for call in self._calls(graph):
-            caller_parent_id = call.get("parent_id")
+        for site in sorted(
+            graph.call_sites,
+            key=lambda s: (s["relative_path"], s["lineno"], s["col_offset"]),
+        ):
+            caller_parent_id = site.get("parent_id")
             if not caller_parent_id:
                 continue
 
@@ -189,13 +201,9 @@ class RepoGraphBuilder:
             if not caller_parent:
                 continue
 
-            name = call.get("name") or ""
-            resolution, confidence = self._resolve_in_scope(call, graph)
-
-            if not resolution:
-                resolution = symbol_table.lookup(name)
-                confidence = 0.5 if resolution else 0.0
-
+            resolution, confidence = self._resolve_call_site(
+                site, graph, symbol_table
+            )
             if not resolution:
                 continue
 
@@ -205,12 +213,49 @@ class RepoGraphBuilder:
             if not target:
                 continue
 
+            key = (caller_parent["canonical_id"], target["canonical_id"])
+            record = edges.setdefault(
+                key, {"linenos": [], "confidence": confidence}
+            )
+            record["linenos"].append(site["lineno"])
+            record["confidence"] = max(record["confidence"], confidence)
+
+        for (from_cid, to_cid) in sorted(edges):
+            record = edges[(from_cid, to_cid)]
             graph.add_relationship({
-                "from_canonical_id": caller_parent["canonical_id"],
-                "to_canonical_id": target["canonical_id"],
+                "from_canonical_id": from_cid,
+                "to_canonical_id": to_cid,
                 "relation_type": "CALL",
-                "relationship_metadata": {"confidence": confidence}
+                "relationship_metadata": {
+                    "confidence": record["confidence"],
+                    "call_sites": record["linenos"],
+                    "count": len(record["linenos"]),
+                },
             })
+
+    def _resolve_call_site(
+        self, site: dict, graph: RepoGraph, symbol_table
+    ) -> Tuple[Optional[str], float]:
+        """Resolve one call site to an extractor-local entity id.
+
+        F-03 keeps the pre-existing resolution semantics (enclosing-scope
+        recursion match, then flat global symbol table) for receiver-less
+        calls; receiver calls (`self.x()`, `obj.x()`) resolve in F-04.
+        """
+        if site.get("receiver") is not None:
+            return None, 0.0
+
+        resolution, confidence = self._resolve_in_scope(site, graph)
+        if resolution:
+            return resolution, confidence
+
+        resolution = symbol_table.lookup(site.get("name") or "")
+        if resolution:
+            # symbol_table stores canonical ids; edge emission expects the
+            # extractor-local id, which for code artifacts is identical.
+            return resolution, 0.5
+
+        return None, 0.0
 
     # -----------------------------
     # IS8: DOCUMENTS Relationships
@@ -293,21 +338,18 @@ class RepoGraphBuilder:
     # Helpers
     # -----------------------------
 
-    def _calls(self, graph: RepoGraph):
-        for entity in graph.all_entities():
-            if entity.get("artifact_type") == "CALL":
-                yield entity
-
     def _resolve_in_scope(
-        self, call: dict, graph: RepoGraph
+        self, site: dict, graph: RepoGraph
     ) -> Tuple[Optional[str], float]:
-        current_parent = call.get("parent_id")
+        """Recursion detection: an enclosing scope whose name matches the
+        called name (works for both artifacts and call-site records)."""
+        current_parent = site.get("parent_id")
 
         while current_parent:
             entity = graph.get_entity_by_id(current_parent)
             if entity is None:
                 break
-            if entity.get("name") == call.get("name"):
+            if entity.get("name") == site.get("name"):
                 return entity.get("id"), 1.0
             current_parent = entity.get("parent_id")
 

--- a/ingestion_service/src/core/codebase/repo_graph_builder.py
+++ b/ingestion_service/src/core/codebase/repo_graph_builder.py
@@ -139,6 +139,7 @@ class RepoGraphBuilder:
 
         symbol_table = build_symbol_table(graph)
         self._attach_defines(graph)
+        self._resolve_imports(graph)          # F-02 (WP-G2) — before calls
         self._resolve_calls(graph, symbol_table)
         self._link_docs_to_code(graph, symbol_table)   # IS8 — last step
 
@@ -174,6 +175,169 @@ class RepoGraphBuilder:
                 "relation_type": "DEFINES",
                 "relationship_metadata": {}
             })
+
+    # -----------------------------
+    # F-02 (WP-G2): IMPORTS Relationships
+    # -----------------------------
+
+    def _resolve_imports(self, graph: RepoGraph) -> None:
+        """Materialize MODULE --IMPORTS--> MODULE edges from IMPORT
+        artifacts. Intra-repo imports resolve against the dotted-module
+        map; external imports get one EXTERNAL_MODULE node per root
+        package. Also records per-file import bindings for call
+        resolution (ADR-032 layer 2)."""
+        module_map: dict[str, str] = {}
+        for entity in graph.all_entities():
+            if entity.get("artifact_type") != "MODULE":
+                continue
+            dotted = self._dotted_module_path(entity["canonical_id"])
+            if dotted:
+                module_map[dotted] = entity["canonical_id"]
+
+        imports = sorted(
+            (
+                e for e in graph.all_entities()
+                if e.get("artifact_type") == "IMPORT"
+            ),
+            key=lambda e: (
+                e.get("relative_path", ""),
+                e.get("metadata", {}).get("lineno", 0),
+                e.get("metadata", {}).get("col_offset", 0),
+                e.get("name", ""),
+            ),
+        )
+
+        # (from_cid, to_cid) -> [[imported_name, asname], ...]
+        edges: dict = {}
+
+        for imp in imports:
+            rel = imp.get("relative_path", "")
+            if rel not in graph.entities:
+                continue  # MODULE canonical id == relative path (ADR-031)
+
+            name = imp.get("name", "")
+            asname = imp.get("metadata", {}).get("asname")
+
+            target_cid, binding = self._resolve_import_target(
+                graph, imp, module_map
+            )
+            # `import pkg.util` binds the dotted path as written at call
+            # sites (`pkg.util.calc()`); an asname replaces it.
+            bindings = graph.import_bindings.setdefault(rel, {})
+            bindings[asname or name] = binding
+
+            if target_cid == rel:
+                continue  # a module importing itself is never an edge
+
+            edges.setdefault((rel, target_cid), []).append(
+                [name, asname]
+            )
+
+        for (from_cid, to_cid) in sorted(edges):
+            pairs = sorted(
+                edges[(from_cid, to_cid)],
+                key=lambda p: (p[0], p[1] or ""),
+            )
+            graph.add_relationship({
+                "from_canonical_id": from_cid,
+                "to_canonical_id": to_cid,
+                "relation_type": "IMPORTS",
+                "relationship_metadata": {
+                    "imports": pairs,
+                    "count": len(pairs),
+                },
+            })
+
+    def _resolve_import_target(
+        self, graph: RepoGraph, imp: dict, module_map: dict
+    ) -> Tuple[str, dict]:
+        """Resolve one IMPORT artifact to (target canonical id, binding).
+
+        ImportFrom tries `base.name` as a module first (`from pkg import
+        util`), then `base` as the module the symbol lives in; plain
+        Import tries the dotted name directly. Misses become one
+        EXTERNAL_MODULE per root package.
+        """
+        meta = imp.get("metadata", {})
+        name = imp.get("name", "")
+        rel = imp.get("relative_path", "")
+
+        if "module" not in meta:  # `import X[.Y]`
+            if name in module_map:
+                return module_map[name], {
+                    "kind": "module", "module_cid": module_map[name],
+                }
+            root = name.split(".")[0]
+            return self._external_module_node(graph, root), {
+                "kind": "external_module", "dotted": name,
+            }
+
+        # `from X import name`
+        dotted_base = self._absolute_import_base(
+            rel, meta.get("module", ""), meta.get("level", 0) or 0
+        )
+        as_module = f"{dotted_base}.{name}" if dotted_base else name
+
+        if as_module in module_map:
+            # the imported name is itself a module
+            return module_map[as_module], {
+                "kind": "module", "module_cid": module_map[as_module],
+            }
+        if dotted_base in module_map:
+            return module_map[dotted_base], {
+                "kind": "symbol",
+                "module_cid": module_map[dotted_base],
+                "symbol": name,
+            }
+        root = (dotted_base or name).split(".")[0]
+        return self._external_module_node(graph, root), {
+            "kind": "external_symbol", "dotted": as_module,
+        }
+
+    def _dotted_module_path(self, relative_path: str) -> Optional[str]:
+        """`pkg/util.py` → `pkg.util`; `pkg/__init__.py` → `pkg`."""
+        if not relative_path.endswith(".py"):
+            return None
+        parts = relative_path[:-3].split("/")
+        if parts and parts[-1] == "__init__":
+            parts = parts[:-1]
+        return ".".join(parts) if parts else None
+
+    def _absolute_import_base(
+        self, relative_path: str, base: str, level: int
+    ) -> str:
+        """Resolve an ImportFrom base to an absolute dotted path.
+        level=0 → already absolute; level=n → n-1 packages above the
+        importing file's package."""
+        if not level:
+            return base
+        pkg_parts = relative_path.split("/")[:-1]
+        drop = level - 1
+        pkg_parts = pkg_parts[: len(pkg_parts) - drop] if drop else pkg_parts
+        if base:
+            pkg_parts = pkg_parts + base.split(".")
+        return ".".join(pkg_parts)
+
+    def _external_module_node(self, graph: RepoGraph, root: str) -> str:
+        """Get or create the single EXTERNAL_MODULE node for an external
+        root package (`numpy`, not `numpy.linalg`). Persisted with empty
+        text so it is never embedded (ADR-039)."""
+        canonical_id = f"EXTERNAL_MODULE:{root}"
+        if canonical_id not in graph.entities:
+            graph.add_entity("", {
+                "artifact_type": "EXTERNAL_MODULE",
+                "id": canonical_id,
+                "canonical_id": canonical_id,
+                "name": root,
+                "title": root,
+                "doc_type": "external",
+                "relative_path": "",
+                "text": "",
+                "metadata": {},
+                "ingestion_id": self.ingestion_id,
+                "defines": [],
+            })
+        return canonical_id
 
     # -----------------------------
     # CALL Relationships

--- a/ingestion_service/src/core/codebase/repo_graph_builder.py
+++ b/ingestion_service/src/core/codebase/repo_graph_builder.py
@@ -44,6 +44,10 @@ DEFAULT_IGNORED_DIRS = {
 # col_offset/end_col_offset are byte offsets into the UTF-8 encoded line.
 _LINE_SPLIT = re.compile(r"[^\r\n]*(?:\r\n|[\r\n])?")
 
+# F-04: receivers that are plain dotted names keep their context in
+# EXTERNAL_SYMBOL ids; anything else (subscripts, call results) doesn't.
+_DOTTED_NAME = re.compile(r"^[A-Za-z_]\w*(\.[A-Za-z_]\w*)*$")
+
 
 def _splitlines_no_ff(source: str) -> list[str]:
     lines = _LINE_SPLIT.findall(source)
@@ -163,9 +167,8 @@ class RepoGraphBuilder:
             if not parent_id:
                 continue
 
-            parent = graph.get_entity(
-                self._canonical_from_id(graph, parent_id)
-            )
+            parent_cid = self._canonical_from_id(graph, parent_id)
+            parent = graph.get_entity(parent_cid) if parent_cid else None
             if not parent:
                 continue
 
@@ -359,8 +362,9 @@ class RepoGraphBuilder:
             if not caller_parent_id:
                 continue
 
-            caller_parent = graph.get_entity(
-                self._canonical_from_id(graph, caller_parent_id)
+            caller_cid = self._canonical_from_id(graph, caller_parent_id)
+            caller_parent = (
+                graph.get_entity(caller_cid) if caller_cid else None
             )
             if not caller_parent:
                 continue
@@ -371,9 +375,8 @@ class RepoGraphBuilder:
             if not resolution:
                 continue
 
-            target = graph.get_entity(
-                self._canonical_from_id(graph, resolution)
-            )
+            target_cid = self._canonical_from_id(graph, resolution)
+            target = graph.get_entity(target_cid) if target_cid else None
             if not target:
                 continue
 
@@ -400,26 +403,163 @@ class RepoGraphBuilder:
     def _resolve_call_site(
         self, site: dict, graph: RepoGraph, symbol_table
     ) -> Tuple[Optional[str], float]:
-        """Resolve one call site to an extractor-local entity id.
+        """F-04 (WP-G4): resolve one call site per ADR-032's order:
+        (1) receiver `self`/`cls` → enclosing class's methods;
+        (2) bare name → same-file symbols;
+        (3) name/receiver imported in this file → target module's symbol;
+        (4) global index, only if unambiguous;
+        (5) else an EXTERNAL_SYMBOL node — never silently dropped.
 
-        F-03 keeps the pre-existing resolution semantics (enclosing-scope
-        recursion match, then flat global symbol table) for receiver-less
-        calls; receiver calls (`self.x()`, `obj.x()`) resolve in F-04.
-        """
-        if site.get("receiver") is not None:
-            return None, 0.0
+        Confidence: 1.0 scoped/import-resolved, 0.5 unique-global,
+        0.0 external/unknown. Confidence lives in edge metadata, never
+        in identity (ADR-031)."""
+        name = site.get("name") or ""
+        receiver = site.get("receiver")
 
-        resolution, confidence = self._resolve_in_scope(site, graph)
-        if resolution:
-            return resolution, confidence
+        if receiver in ("self", "cls"):
+            class_id = self._enclosing_class_id(site, graph)
+            if class_id:
+                candidate = f"{class_id}.{name}"
+                if graph.get_entity_by_id(candidate):
+                    return candidate, 1.0
+            return (
+                self._external_symbol_node(graph, f"{receiver}.{name}"),
+                0.0,
+            )
 
-        resolution = symbol_table.lookup(site.get("name") or "")
-        if resolution:
-            # symbol_table stores canonical ids; edge emission expects the
-            # extractor-local id, which for code artifacts is identical.
-            return resolution, 0.5
+        if receiver is None:
+            return self._resolve_bare_call(site, graph, symbol_table)
 
-        return None, 0.0
+        return self._resolve_attribute_call(site, graph, symbol_table)
+
+    def _resolve_bare_call(
+        self, site: dict, graph: RepoGraph, symbol_table
+    ) -> Tuple[str, float]:
+        name = site.get("name") or ""
+        rel = site.get("relative_path", "")
+
+        local = symbol_table.lookup_in_file(rel, name)
+        if local:
+            return local, 1.0
+
+        binding = graph.import_bindings.get(rel, {}).get(name)
+        if binding:
+            return self._resolve_via_binding(
+                graph, symbol_table, binding, None
+            )
+
+        candidates = symbol_table.lookup_global(name)
+        if len(candidates) == 1:
+            return candidates[0], 0.5
+
+        # zero candidates (unknown/builtin) or >1 (ambiguous): surface
+        # as external instead of guessing an arbitrary winner.
+        return self._external_symbol_node(graph, name), 0.0
+
+    def _resolve_attribute_call(
+        self, site: dict, graph: RepoGraph, symbol_table
+    ) -> Tuple[str, float]:
+        name = site.get("name") or ""
+        receiver = site.get("receiver") or ""
+        rel = site.get("relative_path", "")
+
+        binding = graph.import_bindings.get(rel, {}).get(receiver)
+        if binding:
+            return self._resolve_via_binding(
+                graph, symbol_table, binding, name
+            )
+
+        # receiver may be a class in the same file: `Calculator.add()`
+        local_receiver = symbol_table.lookup_in_file(rel, receiver)
+        if local_receiver:
+            candidate = f"{local_receiver}.{name}"
+            if graph.get_entity_by_id(candidate):
+                return candidate, 1.0
+
+        # dynamic receivers (`items[0].strip()`, `get_db().query`) fold
+        # into the bare method name; dotted-name receivers keep context.
+        external_name = (
+            f"{receiver}.{name}"
+            if _DOTTED_NAME.match(receiver)
+            else name
+        )
+        return self._external_symbol_node(graph, external_name), 0.0
+
+    def _resolve_via_binding(
+        self, graph: RepoGraph, symbol_table, binding: dict, attr: Optional[str]
+    ) -> Tuple[str, float]:
+        """Resolve a call through an import binding (ADR-032 layer 2).
+        `attr` is None for `calc()` where calc itself was imported, or
+        the called attribute for `utils.calc()` / `numpy.array()`."""
+        kind = binding["kind"]
+
+        if kind == "module":
+            module_cid = binding["module_cid"]
+            dotted = self._dotted_module_path(module_cid) or module_cid
+            if attr is None:
+                # calling a module object — nothing to resolve to
+                return self._external_symbol_node(graph, dotted), 0.0
+            target = symbol_table.lookup_in_file(module_cid, attr)
+            if target:
+                return target, 1.0
+            return (
+                self._external_symbol_node(graph, f"{dotted}.{attr}"),
+                0.0,
+            )
+
+        if kind == "symbol":
+            module_cid = binding["module_cid"]
+            symbol = binding["symbol"]
+            target = symbol_table.lookup_in_file(module_cid, symbol)
+            if attr is None:
+                if target:
+                    return target, 1.0
+            elif target:
+                # imported class used as receiver: `Calculator.add()`
+                candidate = f"{target}.{attr}"
+                if graph.get_entity_by_id(candidate):
+                    return candidate, 1.0
+            dotted = self._dotted_module_path(module_cid) or module_cid
+            external = f"{dotted}.{symbol}" + (f".{attr}" if attr else "")
+            return self._external_symbol_node(graph, external), 0.0
+
+        # external_module / external_symbol
+        external = binding["dotted"] + (f".{attr}" if attr else "")
+        return self._external_symbol_node(graph, external), 0.0
+
+    def _enclosing_class_id(
+        self, site: dict, graph: RepoGraph
+    ) -> Optional[str]:
+        """Nearest enclosing CLASS of a call site (via the parent chain)."""
+        current = site.get("parent_id")
+        while current:
+            entity = graph.get_entity_by_id(current)
+            if entity is None:
+                return None
+            if entity.get("artifact_type") == "CLASS":
+                return entity.get("id")
+            current = entity.get("parent_id")
+        return None
+
+    def _external_symbol_node(self, graph: RepoGraph, dotted: str) -> str:
+        """Get or create the EXTERNAL_SYMBOL node for an unresolved
+        callee (`requests.get`, `print`). Empty text — never embedded."""
+        canonical_id = f"EXTERNAL_SYMBOL:{dotted}"
+        if canonical_id not in graph.entities:
+            graph.add_entity("", {
+                "artifact_type": "EXTERNAL_SYMBOL",
+                "id": canonical_id,
+                "canonical_id": canonical_id,
+                "name": dotted,
+                "title": dotted,
+                "doc_type": "external",
+                "relative_path": "",
+                "text": "",
+                "metadata": {},
+                "ingestion_id": self.ingestion_id,
+                "defines": [],
+            })
+        return canonical_id
 
     # -----------------------------
     # IS8: DOCUMENTS Relationships
@@ -501,23 +641,6 @@ class RepoGraphBuilder:
     # -----------------------------
     # Helpers
     # -----------------------------
-
-    def _resolve_in_scope(
-        self, site: dict, graph: RepoGraph
-    ) -> Tuple[Optional[str], float]:
-        """Recursion detection: an enclosing scope whose name matches the
-        called name (works for both artifacts and call-site records)."""
-        current_parent = site.get("parent_id")
-
-        while current_parent:
-            entity = graph.get_entity_by_id(current_parent)
-            if entity is None:
-                break
-            if entity.get("name") == site.get("name"):
-                return entity.get("id"), 1.0
-            current_parent = entity.get("parent_id")
-
-        return None, 0.0
 
     def _canonical_from_id(
         self, graph: RepoGraph, entity_id: str

--- a/ingestion_service/src/core/codebase/symbol_table.py
+++ b/ingestion_service/src/core/codebase/symbol_table.py
@@ -1,76 +1,87 @@
-## ingestion_service\src\core\codebase\symbol_table.py
+# ingestion_service\src\core\codebase\symbol_table.py
 """
 src/core/codebase/symbol_table.py
 
-SymbolTable
+SymbolTable — two-layer symbol index (F-04 / WP-G4, ADR-032).
 
-Builds a repository-wide mapping:
+Layers:
+- per-file: relative_path -> symbol_name -> canonical_id
+  (FUNCTION/CLASS shadow METHODs of the same bare name; ties resolve to
+  the lexicographically smallest canonical id — deterministic.)
+- global: symbol_name -> sorted list of canonical_ids
+  (a list, so ambiguity is surfaced instead of last-write-wins.)
 
-    symbol_name -> canonical_id
-
-Phase 1 scope:
-- CLASS
-- FUNCTION
-- METHOD
-
-This is a global flat symbol index.
-Later phases may extend to scoped or multi-binding resolution.
+Indexed artifact types: CLASS, FUNCTION, METHOD.
 """
-from __future__ import annotations  # Python 3.7+ feature
-#to try and avoid circular reference
-#from src.core.codebase.repo_graph_builder import RepoGraph
+from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List, Optional, Tuple
+
+# FUNCTION/CLASS are callable/referable by bare name; METHOD is not,
+# so it only matches when nothing else in the file has the name.
+_PRIORITY = {"CLASS": 0, "FUNCTION": 0, "METHOD": 1}
 
 
 class SymbolTable:
-    """
-    Global symbol table for repository artifacts.
-
-    Maps:
-        symbol_name -> canonical_id
-    """
+    """Two-layer symbol table for repository artifacts."""
 
     def __init__(self):
-        self._symbols: Dict[str, str] = {}
+        # relative_path -> name -> (priority, canonical_id)
+        self._per_file: Dict[str, Dict[str, Tuple[int, str]]] = {}
+        # name -> list of canonical_ids (kept sorted on read)
+        self._global: Dict[str, List[str]] = {}
 
     # ------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------
 
-    def add(self, symbol_name: str, canonical_id: str):
-        """
-        Register a symbol in the table.
+    def add(
+        self,
+        symbol_name: str,
+        canonical_id: str,
+        relative_path: Optional[str] = None,
+        artifact_type: str = "FUNCTION",
+    ):
+        """Register a symbol in both layers."""
+        self._global.setdefault(symbol_name, []).append(canonical_id)
 
-        If duplicate symbol exists, last definition wins.
-        (Phase 1 simplification — deterministic but not scoped.)
-        """
-        self._symbols[symbol_name] = canonical_id
+        if relative_path:
+            candidate = (
+                _PRIORITY.get(artifact_type, 1), canonical_id
+            )
+            bucket = self._per_file.setdefault(relative_path, {})
+            existing = bucket.get(symbol_name)
+            if existing is None or candidate < existing:
+                bucket[symbol_name] = candidate
 
     def lookup(self, symbol_name: str) -> str | None:
-        """
-        Retrieve canonical_id for a symbol.
-        """
-        return self._symbols.get(symbol_name)
+        """Repo-wide lookup; ambiguous names resolve to the smallest
+        canonical id (deterministic first match — ADR-048)."""
+        bucket = self._global.get(symbol_name)
+        return min(bucket) if bucket else None
+
+    def lookup_in_file(
+        self, relative_path: str, symbol_name: str
+    ) -> Optional[str]:
+        """Same-file lookup (ADR-032 resolution layer 1)."""
+        entry = self._per_file.get(relative_path, {}).get(symbol_name)
+        return entry[1] if entry else None
+
+    def lookup_global(self, symbol_name: str) -> List[str]:
+        """All bindings of a name across the repo, sorted. Callers use
+        this only when unambiguous (len == 1) — ADR-032 layer 3."""
+        return sorted(self._global.get(symbol_name, []))
 
     def all_symbols(self) -> Dict[str, str]:
-        return dict(self._symbols)
+        return {name: min(cids) for name, cids in self._global.items()}
 
 
 # ----------------------------------------------------------------
 # Builder Function
 # ----------------------------------------------------------------
 
-def build_symbol_table(graph: RepoGraph) -> SymbolTable:
-    """
-    Build a SymbolTable from a RepoGraph.
-
-    Indexes:
-        CLASS
-        FUNCTION
-        METHOD
-    """
-
+def build_symbol_table(graph) -> SymbolTable:
+    """Build a SymbolTable from a RepoGraph (CLASS/FUNCTION/METHOD)."""
     table = SymbolTable()
 
     for entity in graph.all_entities():
@@ -78,11 +89,14 @@ def build_symbol_table(graph: RepoGraph) -> SymbolTable:
 
         if artifact_type in {"CLASS", "FUNCTION", "METHOD"}:
             name = entity.get("name")
-            #canonical_id = entity.get("id")
-            canonical_id = entity.get("canonical_id")   
+            canonical_id = entity.get("canonical_id")
 
             if isinstance(name, str) and isinstance(canonical_id, str):
-                table.add(name, canonical_id)
-
+                table.add(
+                    name,
+                    canonical_id,
+                    relative_path=entity.get("relative_path"),
+                    artifact_type=artifact_type,
+                )
 
     return table

--- a/ingestion_service/src/core/extractors/python_extractor.py
+++ b/ingestion_service/src/core/extractors/python_extractor.py
@@ -11,7 +11,6 @@ Extracts code artifacts from Python source files:
 - FUNCTION
 - METHOD
 - IMPORT
-- CALL (unresolved)
 
 All artifacts include:
 - canonical id
@@ -21,6 +20,11 @@ All artifacts include:
 - parent_id (except MODULE)
 
 Hierarchical relationships are explicitly encoded using a scope stack.
+
+Call sites are NOT artifacts (F-03 / WP-G3): they carry no identity, so they
+are collected in `self.call_sites` as evidence records
+{name, receiver, parent_id, relative_path, lineno, col_offset} and consumed
+by RepoGraphBuilder._resolve_calls to produce aggregated CALL edges.
 """
 
 import ast
@@ -40,6 +44,8 @@ class PythonASTExtractor(ast.NodeVisitor):
         self.module_name = module_path.replace("/", ".")
         self.module_id = relative_path  # canonical module id
         self.artifacts: List[Dict] = []
+        # F-03: call sites are evidence, not identity-bearing artifacts.
+        self.call_sites: List[Dict] = []
         self.scope_stack: List[str] = []  # maintains current lexical scope
 
     # ------------------------------------------------------------------
@@ -166,24 +172,30 @@ class PythonASTExtractor(ast.NodeVisitor):
             })
 
     def visit_Call(self, node: ast.Call):
+        # F-03: record the call site with the receiver split from the
+        # callee name (`self.add()` → name="add", receiver="self") instead
+        # of a fused string, so resolution can use scope/import context.
         try:
             if isinstance(node.func, ast.Attribute):
-                func_name = f"{ast.unparse(node.func.value)}.{node.func.attr}"
+                name = node.func.attr
+                receiver = ast.unparse(node.func.value)
+            elif isinstance(node.func, ast.Name):
+                name = node.func.id
+                receiver = None
             else:
-                func_name = ast.unparse(node.func)
+                name = ast.unparse(node.func)
+                receiver = None
         except Exception:
-            func_name = "<unknown>"
+            name = "<unknown>"
+            receiver = None
 
-        self.artifacts.append({
-            "artifact_type": "CALL",
-            "id": f"{self.relative_path}#call:{func_name}",
-            "name": func_name,
+        self.call_sites.append({
+            "name": name,
+            "receiver": receiver,
             "parent_id": self._current_parent_id(),
             "relative_path": self.relative_path,
-            "metadata": {
-                "lineno": node.lineno,
-                "col_offset": node.col_offset,
-            },
+            "lineno": node.lineno,
+            "col_offset": node.col_offset,
         })
 
         self.generic_visit(node)

--- a/ingestion_service/src/core/extractors/python_extractor.py
+++ b/ingestion_service/src/core/extractors/python_extractor.py
@@ -166,6 +166,8 @@ class PythonASTExtractor(ast.NodeVisitor):
                 "metadata": {
                     "module": module,
                     "asname": alias.asname,
+                    # F-02: relative-import depth (`from . import x` → 1)
+                    "level": node.level,
                     "lineno": node.lineno,
                     "col_offset": node.col_offset,
                 },

--- a/ingestion_service/tests/codebase/test_call_resolution.py
+++ b/ingestion_service/tests/codebase/test_call_resolution.py
@@ -1,0 +1,152 @@
+# ingestion_service/tests/codebase/test_call_resolution.py
+"""
+F-04 (WP-G4): scope- and import-aware call resolution per ADR-032:
+local scope → file imports → global index (only if unambiguous) →
+EXTERNAL_SYMBOL. Unresolved calls become edges, never silent drops.
+"""
+import pytest
+from uuid import uuid4
+
+from src.core.codebase.repo_graph_builder import RepoGraphBuilder
+
+pytestmark = pytest.mark.unit
+
+
+def _write_repo(tmp_path):
+    (tmp_path / "utils.py").write_text(
+        "def calc():\n    return 1\n", encoding="utf-8"
+    )
+    (tmp_path / "file.py").write_text(
+        "class A:\n"
+        "    def helper(self):\n"
+        "        return 1\n"
+        "\n"
+        "    def run(self):\n"
+        "        return self.helper()\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "app.py").write_text(
+        "import requests\n"
+        "import utils\n"
+        "from utils import calc\n"
+        "\n"
+        "\n"
+        "def use_import():\n"
+        "    return calc()\n"
+        "\n"
+        "\n"
+        "def use_module_receiver():\n"
+        "    return utils.calc()\n"
+        "\n"
+        "\n"
+        "def use_external():\n"
+        "    return requests.get('http://x')\n",
+        encoding="utf-8",
+    )
+    # two same-named functions in different files + a bare call from a
+    # third file → must NOT pick an arbitrary winner
+    (tmp_path / "dup_a.py").write_text(
+        "def dupe():\n    return 'a'\n", encoding="utf-8"
+    )
+    (tmp_path / "dup_b.py").write_text(
+        "def dupe():\n    return 'b'\n", encoding="utf-8"
+    )
+    (tmp_path / "third.py").write_text(
+        "def caller():\n    return dupe()\n", encoding="utf-8"
+    )
+    # unique global symbol called bare from another file (no import)
+    (tmp_path / "solo.py").write_text(
+        "def one_of_a_kind():\n    return 1\n", encoding="utf-8"
+    )
+    (tmp_path / "uses_solo.py").write_text(
+        "def go():\n    return one_of_a_kind()\n", encoding="utf-8"
+    )
+
+
+@pytest.fixture()
+def graph(tmp_path):
+    _write_repo(tmp_path)
+    return RepoGraphBuilder(tmp_path, ingestion_id=str(uuid4())).build()
+
+
+def _call_edges(graph):
+    return [r for r in graph.relationships if r["relation_type"] == "CALL"]
+
+
+def _edge(graph, from_cid, to_cid):
+    matches = [
+        e for e in _call_edges(graph)
+        if e["from_canonical_id"] == from_cid
+        and e["to_canonical_id"] == to_cid
+    ]
+    assert len(matches) <= 1
+    return matches[0] if matches else None
+
+
+def test_self_call_resolves_to_enclosing_class_method(graph):
+    """self.helper() inside class A resolves to file.py#A.helper, 1.0."""
+    edge = _edge(graph, "file.py#A.run", "file.py#A.helper")
+    assert edge is not None
+    assert edge["relationship_metadata"]["confidence"] == 1.0
+
+
+def test_imported_symbol_resolves_cross_file(graph):
+    """from utils import calc; calc() → utils.py#calc, confidence 1.0."""
+    edge = _edge(graph, "app.py#use_import", "utils.py#calc")
+    assert edge is not None
+    assert edge["relationship_metadata"]["confidence"] == 1.0
+
+
+def test_module_receiver_resolves_cross_file(graph):
+    """import utils; utils.calc() → utils.py#calc, confidence 1.0."""
+    edge = _edge(graph, "app.py#use_module_receiver", "utils.py#calc")
+    assert edge is not None
+    assert edge["relationship_metadata"]["confidence"] == 1.0
+
+
+def test_external_call_becomes_queryable_external_symbol(graph):
+    """requests.get → edge to EXTERNAL_SYMBOL:requests.get, conf 0.0."""
+    edge = _edge(graph, "app.py#use_external", "EXTERNAL_SYMBOL:requests.get")
+    assert edge is not None
+    assert edge["relationship_metadata"]["confidence"] == 0.0
+
+    node = graph.get_entity("EXTERNAL_SYMBOL:requests.get")
+    assert node is not None
+    assert node["artifact_type"] == "EXTERNAL_SYMBOL"
+    assert node["doc_type"] == "external"
+    assert node["text"] == ""  # never embedded (ADR-039)
+
+
+def test_ambiguous_global_yields_external_not_arbitrary_winner(graph):
+    """dupe() defined in dup_a.py and dup_b.py, called bare from
+    third.py → EXTERNAL edge, not an arbitrary pick."""
+    assert _edge(graph, "third.py#caller", "dup_a.py#dupe") is None
+    assert _edge(graph, "third.py#caller", "dup_b.py#dupe") is None
+
+    edge = _edge(graph, "third.py#caller", "EXTERNAL_SYMBOL:dupe")
+    assert edge is not None
+    assert edge["relationship_metadata"]["confidence"] == 0.0
+
+
+def test_unique_global_resolves_with_half_confidence(graph):
+    """one_of_a_kind() is globally unique → resolves at 0.5."""
+    edge = _edge(graph, "uses_solo.py#go", "solo.py#one_of_a_kind")
+    assert edge is not None
+    assert edge["relationship_metadata"]["confidence"] == 0.5
+
+
+def test_unresolved_self_call_goes_external(graph):
+    """No calls are silently dropped: every call site lands in an edge."""
+    # str() call receiver 'http://x' argument aside — sanity: all sites
+    # of app.py map to some edge from their enclosing scope.
+    froms = {e["from_canonical_id"] for e in _call_edges(graph)}
+    assert {"app.py#use_import", "app.py#use_module_receiver",
+            "app.py#use_external"} <= froms
+
+
+def test_rebuild_determinism(tmp_path):
+    _write_repo(tmp_path)
+    g1 = RepoGraphBuilder(tmp_path, ingestion_id="fixed-id").build()
+    g2 = RepoGraphBuilder(tmp_path, ingestion_id="fixed-id").build()
+    assert g1.relationships == g2.relationships
+    assert sorted(g1.entities.keys()) == sorted(g2.entities.keys())

--- a/ingestion_service/tests/codebase/test_extractor_fixes.py
+++ b/ingestion_service/tests/codebase/test_extractor_fixes.py
@@ -97,15 +97,17 @@ def test_sync_defs_marked_not_async(async_artifacts):
     assert funcs["app.py#Handler.load"]["metadata"]["is_async"] is False
 
 
-def test_calls_inside_async_body_attributed_to_async_def(async_artifacts):
-    """Before F-01 the CALL inside `async def main` had the MODULE as its
-    parent — mis-attributing the caller."""
-    calls = {
-        a["name"]: a for a in async_artifacts
-        if a["artifact_type"] == "CALL"
+def test_calls_inside_async_body_attributed_to_async_def():
+    """Before F-01 the call site inside `async def main` had the MODULE as
+    its parent — mis-attributing the caller. F-03: call sites live in the
+    extractor's side list with the receiver split from the name."""
+    extractor = PythonASTExtractor(relative_path="app.py")
+    extractor.extract(ASYNC_SOURCE)
+    sites = {
+        (s["receiver"], s["name"]): s for s in extractor.call_sites
     }
-    assert calls["helper"]["parent_id"] == "app.py#main"
-    assert calls["self.load"]["parent_id"] == "app.py#Handler.handle"
+    assert sites[(None, "helper")]["parent_id"] == "app.py#main"
+    assert sites[("self", "load")]["parent_id"] == "app.py#Handler.handle"
 
 
 def test_async_def_end_to_end_through_graph_builder(tmp_path):

--- a/ingestion_service/tests/codebase/test_imports_edges.py
+++ b/ingestion_service/tests/codebase/test_imports_edges.py
@@ -1,0 +1,120 @@
+# ingestion_service/tests/codebase/test_imports_edges.py
+"""
+F-02 (WP-G2): MODULE --IMPORTS--> MODULE edges materialize from IMPORT
+artifacts; external imports get one EXTERNAL_MODULE node per root package.
+"""
+import pytest
+from uuid import uuid4
+
+from src.core.codebase.repo_graph_builder import RepoGraphBuilder
+
+pytestmark = pytest.mark.unit
+
+
+def _write_repo(tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "pkg" / "util.py").write_text(
+        "def helper():\n    return 1\n", encoding="utf-8"
+    )
+    (tmp_path / "pkg" / "sibling.py").write_text(
+        "from . import util\n"
+        "from .util import helper\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "app.py").write_text(
+        "from pkg.util import helper\n"
+        "import numpy\n"
+        "import numpy.linalg\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "other.py").write_text(
+        "import numpy as np\n"
+        "import pkg.util\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def graph(tmp_path):
+    _write_repo(tmp_path)
+    return RepoGraphBuilder(tmp_path, ingestion_id=str(uuid4())).build()
+
+
+def _imports_edges(graph):
+    return [
+        r for r in graph.relationships if r["relation_type"] == "IMPORTS"
+    ]
+
+
+def _edge_set(graph):
+    return {
+        (e["from_canonical_id"], e["to_canonical_id"])
+        for e in _imports_edges(graph)
+    }
+
+
+def test_from_import_yields_module_edge(graph):
+    """`from pkg.util import helper` in app.py → app.py IMPORTS pkg/util.py"""
+    assert ("app.py", "pkg/util.py") in _edge_set(graph)
+
+
+def test_relative_imports_resolve(graph):
+    """`from . import util` and `from .util import helper` in pkg/sibling.py"""
+    assert ("pkg/sibling.py", "pkg/util.py") in _edge_set(graph)
+
+
+def test_plain_dotted_import_resolves(graph):
+    """`import pkg.util` in other.py → other.py IMPORTS pkg/util.py"""
+    assert ("other.py", "pkg/util.py") in _edge_set(graph)
+
+
+def test_external_module_node_is_singleton(graph):
+    """`import numpy`, `import numpy.linalg`, `import numpy as np` across
+    two files → exactly one EXTERNAL_MODULE node named numpy."""
+    externals = [
+        e for e in graph.all_entities()
+        if e["artifact_type"] == "EXTERNAL_MODULE"
+    ]
+    assert len(externals) == 1
+    node = externals[0]
+    assert node["name"] == "numpy"
+    assert node["canonical_id"] == "EXTERNAL_MODULE:numpy"
+    assert node["doc_type"] == "external"
+    assert node["text"] == ""  # never embedded (ADR-039)
+
+    assert ("app.py", "EXTERNAL_MODULE:numpy") in _edge_set(graph)
+    assert ("other.py", "EXTERNAL_MODULE:numpy") in _edge_set(graph)
+
+
+def test_edges_aggregate_per_module_pair(graph):
+    """app.py imports numpy twice (numpy, numpy.linalg) → one edge,
+    both imported names in metadata."""
+    edges = [
+        e for e in _imports_edges(graph)
+        if e["from_canonical_id"] == "app.py"
+        and e["to_canonical_id"] == "EXTERNAL_MODULE:numpy"
+    ]
+    assert len(edges) == 1
+    meta = edges[0]["relationship_metadata"]
+    assert meta["count"] == 2
+    assert [p[0] for p in meta["imports"]] == ["numpy", "numpy.linalg"]
+
+
+def test_import_bindings_recorded_for_call_resolution(graph):
+    """F-04 consumes per-file bindings (ADR-032 layer 2)."""
+    app = graph.import_bindings["app.py"]
+    assert app["helper"] == {
+        "kind": "symbol", "module_cid": "pkg/util.py", "symbol": "helper",
+    }
+    other = graph.import_bindings["other.py"]
+    assert other["np"] == {"kind": "external_module", "dotted": "numpy"}
+    assert other["pkg.util"] == {"kind": "module", "module_cid": "pkg/util.py"}
+
+
+def test_rebuild_determinism_with_imports(tmp_path):
+    _write_repo(tmp_path)
+    g1 = RepoGraphBuilder(tmp_path, ingestion_id="fixed-id").build()
+    g2 = RepoGraphBuilder(tmp_path, ingestion_id="fixed-id").build()
+    assert g1.relationships == g2.relationships
+    assert sorted(g1.entities.keys()) == sorted(g2.entities.keys())

--- a/ingestion_service/tests/codebase/test_python_extractor.py
+++ b/ingestion_service/tests/codebase/test_python_extractor.py
@@ -65,11 +65,11 @@ def test_extractor_on_self_file(extractor):
     assert "typing" in import_modules  # ensure the module itself is tracked in metadata
 
     # -----------------------------
-    # Call artifacts (unresolved)
+    # Call sites (F-03: evidence list, not artifacts)
     # -----------------------------
-    call_artifacts = [a for a in artifacts if a["artifact_type"] == "CALL"]
-    call_names = [c["name"] for c in call_artifacts]
+    assert not any(a["artifact_type"] == "CALL" for a in artifacts)
+    site_keys = {(s["receiver"], s["name"]) for s in extractor.call_sites}
 
     # Check at least one known call exists: ast.unparse used in extractor
-    assert any("ast.unparse" in c for c in call_names)
+    assert ("ast", "unparse") in site_keys
 

--- a/ingestion_service/tests/codebase/test_repo_graph_builder.py
+++ b/ingestion_service/tests/codebase/test_repo_graph_builder.py
@@ -1,4 +1,11 @@
-# ingestion_service/tests/scripts/test_repo_graph_builder.py
+# ingestion_service/tests/codebase/test_repo_graph_builder.py
+"""
+RepoGraphBuilder tests.
+
+F-03 (WP-G3): call sites are evidence records, not identity-bearing
+artifacts — CALL never appears in graph.entities; callers/callees are
+linked by aggregated CALL edges carrying call-site linenos and a count.
+"""
 import pytest
 from pathlib import Path
 from uuid import uuid4
@@ -6,158 +13,152 @@ from uuid import uuid4
 from src.core.codebase.repo_graph_builder import RepoGraphBuilder
 from src.core.codebase.symbol_table import build_symbol_table
 
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------
+# Smoke tests over this service's own src tree
+# ---------------------------------------------------------------------
 
 @pytest.fixture(scope="module")
 def repo_graph():
-    """
-    Build the repo graph once for the whole test module.
-    """
-    # Adjust path if needed; here we use the `src` folder in the repo root
+    """Build the repo graph once for the whole test module."""
     ingestion_id = uuid4()
     repo_root = Path(__file__).resolve().parent.parent.parent / "src"
-    builder = RepoGraphBuilder(repo_root,ingestion_id=ingestion_id)
+    builder = RepoGraphBuilder(repo_root, ingestion_id=ingestion_id)
     return builder.build()
 
 
 @pytest.fixture(scope="module")
 def symbol_table(repo_graph):
-    """
-    Build the symbol table from the repo graph.
-    """
     return build_symbol_table(repo_graph)
 
 
 def test_total_artifacts(repo_graph):
-    """
-    Ensure some artifacts were collected.
-    """
     assert len(repo_graph.entities) > 0, "No artifacts were collected"
 
 
-def test_some_calls_resolved(repo_graph, symbol_table):
-    """
-    Check that CALL artifacts have resolution and parent_id.
-    """
-    calls = [a for a in repo_graph.all_entities() if a["artifact_type"] == "CALL"]
-    assert calls, "No CALL artifacts found"
-
-    for call in calls[:20]:  # check a sample of 20
-        name = call.get("name")
-        resolution = call.get("resolution")
-        parent = call.get("parent_id")
-
-        assert parent is not None, f"CALL '{name}' has no parent_id"
-
-        # Resolution should either be EXTERNAL or a known canonical ID
-        if resolution != "EXTERNAL":
-            assert resolution in repo_graph.entities or resolution in symbol_table.all_symbols(), (
-                f"CALL '{name}' resolves to unknown ID '{resolution}'"
-            )
-
-
 def test_modules_and_classes_collected(repo_graph):
-    """
-    Ensure modules and classes were extracted.
-    """
     modules = [a for a in repo_graph.all_entities() if a["artifact_type"] == "MODULE"]
     classes = [a for a in repo_graph.all_entities() if a["artifact_type"] == "CLASS"]
-
     assert modules, "No MODULE artifacts collected"
     assert classes, "No CLASS artifacts collected"
 
 
 def test_functions_and_methods_collected(repo_graph):
-    """
-    Ensure functions and methods were extracted.
-    """
-    funcs = [a for a in repo_graph.all_entities() if a["artifact_type"] in ("FUNCTION", "METHOD")]
+    funcs = [
+        a for a in repo_graph.all_entities()
+        if a["artifact_type"] in ("FUNCTION", "METHOD")
+    ]
     assert funcs, "No FUNCTION or METHOD artifacts collected"
 
 
 def test_imports_collected(repo_graph):
-    """
-    Ensure import statements were extracted.
-    """
     imports = [a for a in repo_graph.all_entities() if a["artifact_type"] == "IMPORT"]
     assert imports, "No IMPORT artifacts collected"
 
-def test_call_scoped_resolution(repo_graph):
-    """Verify CALL resolution respects local scope and sets confidence"""
-    calls = [a for a in repo_graph.entities.values() if a["artifact_type"] == "CALL"]
-    assert calls, "No CALL artifacts found"
 
-    for call in calls:
-        # Confidence must exist
-        assert "confidence" in call, f"CALL '{call['name']}' missing confidence"
-        conf = call["confidence"]
-        assert 0.0 <= conf <= 1.0, f"CALL '{call['name']}' confidence out of range"
-
-        # Parent ID must exist
-        assert call.get("parent_id") is not None, f"CALL '{call['name']}' missing parent_id"
-
-        # If resolved, resolution should exist in graph
-        if call["resolution"] != "EXTERNAL":
-            assert call["resolution"] in repo_graph.entities, (
-                f"CALL '{call['name']}' resolution points to unknown artifact '{call['resolution']}'"
-            )
-
-def test_defines_relationships(repo_graph):
-    for entity in repo_graph.all_entities():
-        defines = entity.get("defines", None)
-        assert defines is not None, f"Entity '{entity.get('id')}' missing 'defines'"
-
-        container_id = entity["id"]  # ← fix is here
-
-        for did in defines:
-            assert did in repo_graph.entities, (
-                f"Entity '{entity.get('id')}' defines unknown artifact '{did}'"
-            )
-
-            defined_entity = repo_graph.get_entity(did)
-            parent_id = defined_entity.get("parent_id")
-
-            remaining = defined_entity["id"][len(container_id):]
-            if remaining.count("#") <= 1:
-                assert parent_id == container_id, (
-                    f"Defined entity '{did}' parent_id '{parent_id}' does not match container '{entity['id']}'"
-                )
-
-def test_call_resolution_nested(repo_graph):
-    """
-    Verify CALL resolution respects nested scopes:
-    - Method calling another method in same class
-    - Class calling module-level function
-    - Module-level call to global symbol
-    - Unresolved calls marked as EXTERNAL
-    """
+def test_no_call_entities_in_graph(repo_graph):
+    """F-03: CALL is not an identity-bearing artifact — zero CALL entities."""
     calls = [a for a in repo_graph.all_entities() if a["artifact_type"] == "CALL"]
-    assert calls, "No CALL artifacts found"
+    assert calls == [], "CALL artifacts must not enter the identity space"
 
-    for call in calls:
-        name = call.get("name")
-        resolution = call.get("resolution")
-        confidence = call.get("confidence")
-        parent = call.get("parent_id")
 
-        # All calls must have confidence and parent
-        assert parent is not None, f"CALL '{name}' missing parent_id"
-        assert 0.0 <= confidence <= 1.0, f"CALL '{name}' confidence {confidence} out of range"
+def test_call_sites_collected_as_evidence(repo_graph):
+    """The evidence side-list replaces CALL artifacts."""
+    assert repo_graph.call_sites, "No call sites collected"
+    for site in repo_graph.call_sites[:50]:
+        assert "name" in site
+        assert "receiver" in site
+        assert site.get("parent_id") is not None
+        assert isinstance(site.get("lineno"), int)
 
-        # Resolution must exist in graph or be EXTERNAL
-        if resolution != "EXTERNAL":
-            assert resolution in repo_graph.entities, f"CALL '{name}' resolves to unknown artifact '{resolution}'"
 
-def test_call_external_fallback(repo_graph):
-    """
-    Ensure unresolved CALLs are marked as EXTERNAL with confidence 0.0
-    """
-    calls = [a for a in repo_graph.all_entities() if a["artifact_type"] == "CALL"]
-    assert calls, "No CALL artifacts found"
+def test_call_edges_reference_known_entities(repo_graph):
+    call_edges = [
+        r for r in repo_graph.relationships if r["relation_type"] == "CALL"
+    ]
+    assert call_edges, "No CALL edges produced"
+    for edge in call_edges:
+        assert edge["from_canonical_id"] in repo_graph.entities
+        assert edge["to_canonical_id"] in repo_graph.entities
+        meta = edge["relationship_metadata"]
+        assert 0.0 <= meta["confidence"] <= 1.0
+        assert meta["count"] == len(meta["call_sites"]) >= 1
 
-    for call in calls:
-        name = call.get("name")
-        resolution = call.get("resolution")
-        confidence = call.get("confidence")
 
-        if resolution == "EXTERNAL":
-            assert confidence == 0.0, f"External CALL '{name}' should have confidence 0.0"
+def test_defines_edges_reference_known_entities(repo_graph):
+    defines = [
+        r for r in repo_graph.relationships if r["relation_type"] == "DEFINES"
+    ]
+    assert defines, "No DEFINES edges produced"
+    for edge in defines:
+        assert edge["from_canonical_id"] in repo_graph.entities
+        assert edge["to_canonical_id"] in repo_graph.entities
+
+
+# ---------------------------------------------------------------------
+# WP-G3 acceptance criteria on a synthetic repo
+# ---------------------------------------------------------------------
+
+CALLS_SOURCE = (
+    "def foo():\n"
+    "    return 1\n"
+    "\n"
+    "\n"
+    "def bar():\n"
+    "    foo()\n"
+    "    return foo()\n"
+    "\n"
+    "\n"
+    "def baz():\n"
+    "    return foo()\n"
+)
+
+
+@pytest.fixture()
+def calls_graph(tmp_path):
+    (tmp_path / "app.py").write_text(CALLS_SOURCE, encoding="utf-8")
+    return RepoGraphBuilder(tmp_path, ingestion_id=str(uuid4())).build()
+
+
+def _call_edges(graph):
+    return [r for r in graph.relationships if r["relation_type"] == "CALL"]
+
+
+def test_repeated_calls_aggregate_into_one_edge(calls_graph):
+    """Calling foo() twice from bar() → one CALL edge, count 2, both linenos."""
+    edges = [
+        e for e in _call_edges(calls_graph)
+        if e["from_canonical_id"] == "app.py#bar"
+        and e["to_canonical_id"] == "app.py#foo"
+    ]
+    assert len(edges) == 1, f"Expected one aggregated edge, got {edges}"
+    meta = edges[0]["relationship_metadata"]
+    assert meta["count"] == 2
+    assert meta["call_sites"] == [6, 7]
+
+
+def test_distinct_callers_get_distinct_edges(calls_graph):
+    """No last-write-wins: bar and baz each get their own edge to foo."""
+    froms = {
+        e["from_canonical_id"]
+        for e in _call_edges(calls_graph)
+        if e["to_canonical_id"] == "app.py#foo"
+    }
+    assert froms == {"app.py#bar", "app.py#baz"}
+
+
+def test_no_call_rows_in_synthetic_graph(calls_graph):
+    assert not any(
+        a["artifact_type"] == "CALL" for a in calls_graph.all_entities()
+    )
+
+
+def test_rebuild_determinism(tmp_path):
+    """Two consecutive builds produce identical entity and edge sets."""
+    (tmp_path / "app.py").write_text(CALLS_SOURCE, encoding="utf-8")
+    g1 = RepoGraphBuilder(tmp_path, ingestion_id="fixed-id").build()
+    g2 = RepoGraphBuilder(tmp_path, ingestion_id="fixed-id").build()
+    assert sorted(g1.entities.keys()) == sorted(g2.entities.keys())
+    assert g1.relationships == g2.relationships

--- a/ingestion_service/tests/scripts/test_ast_extraction.py
+++ b/ingestion_service/tests/scripts/test_ast_extraction.py
@@ -91,11 +91,11 @@ def test_extractor_on_self_file(extractor):
     assert "typing" in import_modules
 
     # ----------------------------
-    # Call artifacts (unresolved)
+    # Call sites (F-03: evidence list, not artifacts)
     # ----------------------------
-    call_artifacts = [a for a in artifacts if a["artifact_type"] == "CALL"]
-    call_names = [c["name"] for c in call_artifacts]
+    assert not any(a["artifact_type"] == "CALL" for a in artifacts)
+    site_keys = {(s["receiver"], s["name"]) for s in extractor.call_sites}
 
-    # Ensure at least one known call exists
-    assert any("ast.unparse" in c for c in call_names)
-    assert any("setattr" in c for c in call_names)
+    # Ensure known calls exist
+    assert ("ast", "unparse") in site_keys
+    assert (None, "setattr") in site_keys

--- a/rag_orchestrator/src/retrieval/codebase_queries.py
+++ b/rag_orchestrator/src/retrieval/codebase_queries.py
@@ -110,8 +110,13 @@ def traverse_incoming_calls(graph: CodebaseGraph, start_cid: str, depth: int = 3
 
 
 def traverse_incoming_imports(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
-    """Traverse IMPORT edges in reverse (what imports this node?)."""
-    return bfs_traversal(graph, start_cid, relation_types={"IMPORT"}, direction="reverse", max_depth=depth)
+    """Traverse IMPORTS edges in reverse (what imports this node?).
+
+    F-02: ingestion now materializes MODULE --IMPORTS--> MODULE edges
+    (relation_type "IMPORTS"); the old "IMPORT" type never existed as an
+    edge, so this traversal used to return nothing.
+    """
+    return bfs_traversal(graph, start_cid, relation_types={"IMPORTS"}, direction="reverse", max_depth=depth)
 
 # --- API Calls ---
 

--- a/rag_orchestrator/tests/test_imports_traversal.py
+++ b/rag_orchestrator/tests/test_imports_traversal.py
@@ -1,0 +1,45 @@
+# rag_orchestrator/tests/test_imports_traversal.py
+"""
+F-02: `traverse_incoming_imports` must traverse the IMPORTS edges that
+ingestion now materializes (the old "IMPORT" relation type never existed
+as an edge, so the traversal silently returned nothing).
+"""
+import pytest
+
+from src.retrieval.codebase_queries import (
+    CodebaseGraph,
+    Node,
+    traverse_incoming_imports,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _graph_with_imports():
+    graph = CodebaseGraph()
+    for cid in ("app.py", "other.py", "pkg/util.py"):
+        graph.add_node(Node(canonical_id=cid, file_path=cid))
+    graph.add_edge("app.py", "pkg/util.py", "IMPORTS")
+    graph.add_edge("other.py", "pkg/util.py", "IMPORTS")
+    return graph
+
+
+def test_incoming_imports_returns_importers():
+    graph = _graph_with_imports()
+    importers = {
+        n.canonical_id
+        for n in traverse_incoming_imports(graph, "pkg/util.py", depth=1)
+    }
+    assert importers == {"app.py", "other.py"}
+
+
+def test_incoming_imports_ignores_other_edge_types():
+    graph = _graph_with_imports()
+    graph.add_node(Node(canonical_id="caller.py#f", file_path="caller.py"))
+    graph.add_edge("caller.py#f", "pkg/util.py", "CALL")
+
+    importers = {
+        n.canonical_id
+        for n in traverse_incoming_imports(graph, "pkg/util.py", depth=1)
+    }
+    assert "caller.py#f" not in importers


### PR DESCRIPTION
## Summary

Implements the three related graph-resolution findings from the codebase audit (DOCS/audit/01-Codebase-Audit-Findings.md, work packages WP-G2/G3/G4 in 02-Graph-Depth-Analysis.md), in dependency order, plus a committed .env.example template.

### F-03 — remove CALL artifacts from identity space (WP-G3)
- Call sites are evidence records ({name, receiver, parent_id, lineno}) in a side list, with the receiver split from the callee name — no more canonical-id collisions where two calls to foo() in one file overwrote each other.
- One aggregated CALL edge per caller/callee pair with call_sites linenos and count in metadata; CALL rows no longer pollute document_nodes.
- Fixes the 3 long-failing tests in test_repo_graph_builder.py.

### F-02 — materialize IMPORTS edges (WP-G2)
- New _resolve_imports builder step: MODULE --IMPORTS--> MODULE edges for intra-repo imports (dotted-module map, __init__.py package handling, relative-import levels), one EXTERNAL_MODULE node per external root package.
- traverse_incoming_imports in rag_orchestrator now traverses IMPORTS — 'what imports X' queries previously traversed an edge type that was never created and silently returned nothing.
- Per-file import bindings recorded for call resolution.

### F-04 — scope- and import-aware call resolution (WP-G4, implements ADR-032 fully)
- Two-layer SymbolTable: per-file index plus global name -> sorted candidate list (ambiguity surfaced, no last-write-wins).
- Resolution order: self/cls -> enclosing class methods; bare name -> same-file; imported names via F-02 bindings (asname- and module-receiver-aware); global index only when unambiguous; everything else gets an edge to a queryable EXTERNAL_SYMBOL node — unresolved calls are never silently dropped.
- Confidence in edge metadata only: 1.0 scoped/import, 0.5 unique-global, 0.0 external.

## Testing
- 61 ingestion_service unit tests + 7 rag_orchestrator tests pass (new suites: test_imports_edges.py, test_call_resolution.py; test_repo_graph_builder.py rewritten against edges per acceptance criteria).
- Rebuild determinism asserted (identical entity/edge sets across consecutive builds, ADR-030).
- Verified end-to-end against the running Docker stack: ingested /app/shared; persisted graph shows 0 CALL nodes, 62 IMPORTS edges, 85 CALL edges, singleton EXTERNAL_MODULE nodes, and self.x() method calls resolving cross-method (previously near-empty call graph).