### PR TITLE
F-08 + F-09/F-06: batch embedding/persistence and atomic graph rebuild (WP-S2/WP-S3)

### DIFF
--- a/DOCS/test_results/F-08-F-09-batch-atomic-persistence.md
+++ b/DOCS/test_results/F-08-F-09-batch-atomic-persistence.md
@@ -1,0 +1,70 @@
+# F-08 (WP-S2) + F-09/F-06 (WP-S3) — test results
+
+Date: 2026-07-18
+Branch: `post-audit-branch` (commits `43a7232`, `7a882a5`)
+
+## F-08 — batch embedding + persistence
+
+Before: per artifact — 1 SQL lookup (`get_node_by_canonical_id`) + 1 Ollama
+POST + 1 vector-store POST, all serial. 10k artifacts ≈ 10k SQL + 20k HTTP
+round-trips.
+
+After: 1 map query per repo; Ollama called once per `OLLAMA_BATCH_SIZE`
+(50) chunks; vector-store `/v1/vectors/batch` called once per 500 records.
+
+Unit tests (`tests/codebase/test_batch_embedding.py`, 12 tests, all pass):
+
+- ceil(N/500) vector-store HTTP calls asserted via request counter
+  (1200 chunks → exactly 3 POSTs of 500/500/200).
+- `get_canonical_id_map` runs exactly once per ingest; test double raises
+  if the per-node lookup is ever called.
+- OllamaEmbedder splits 120 chunks at batch_size=50 into 3 POSTs of
+  50/50/20, order preserved; raises on count mismatch; no HTTP on empty
+  input.
+- textless and DB-unmapped nodes skipped exactly as before; canonical_id /
+  repo_id / source_metadata injection unchanged.
+
+`get_canonical_id_map` also verified against the docker-compose.test.yml
+Postgres (5433) with real inserts.
+
+## F-09/F-06 — atomic bulk graph persistence + per-repo lock
+
+Before: `upsert_nodes` committed the repo-wide delete in its own
+transaction before inserting (crash ⇒ repo left with no graph); node
+inserts were per-row; relationships cost 3 queries per edge; no
+concurrency control.
+
+After: `persist_graph()` — delete + bulk node insert + bulk relationship
+insert in one transaction, endpoints resolved via an in-memory
+canonical_id→document_id map, `ON CONFLICT DO NOTHING` on
+`uq_document_relationship`, and a transaction-scoped
+`pg_advisory_xact_lock` keyed on repo_id.
+
+Integration tests (`tests/codebase/test_atomic_graph_persistence.py`,
+5 tests, all pass against docker-compose.test.yml Postgres on 5433):
+
+- failed rebuild (unique violation mid-transaction) rolls back fully;
+  the previous graph (nodes and edges) is intact;
+- rebuild fully replaces the prior version (old canonical_ids gone);
+- 3 rounds of two concurrent rebuilds of the same repo with a thread
+  barrier: final state is always exactly one complete version, never a
+  mix;
+- 50 nodes + 49 edges persist in ≤10 SQL statements (old path: ~3 per
+  edge ≈ 150 for the edges alone);
+- unknown-endpoint edges skipped and counted, round-trip shape verified.
+
+## End-to-end (real stack)
+
+Rebuilt `ingestion-service` image and ingested `/app/shared`
+(21 files):
+
+- status `completed`; `Graph persisted: {'deleted': 209, 'nodes': 210,
+  'relationships': 178, 'skipped_relationships': 0}` — prior graph
+  replaced atomically;
+- `Embedded 133 chunks (0 nodes had no DB record)`;
+- DB check: 133 `vector_chunks` rows for the ingestion, 48 distinct
+  `document_id`s — per-chunk document linkage preserved through the
+  batch path.
+
+Regression: full ingestion_service unit suite 73 passed / 1 pre-existing
+skip (3 files excluded per issue #25).

--- a/ingestion_service/src/api/v1/codebase_ingest.py
+++ b/ingestion_service/src/api/v1/codebase_ingest.py
@@ -182,10 +182,14 @@ def _background_ingest_repo(
         persistence = CodebaseGraphPersistence(session=session)
         nodes = repo_graph.all_entities()  # ✅ CORRECT method
         logger.debug(f"[{ingestion_id}] Sample node keys: {nodes[0].keys() if nodes else 'NO NODES'}")
-        persistence.upsert_nodes(repo_id = repo_id, nodes=nodes)
-
-        ## Relationships will be added in MS5 - skip for now
-        persistence.upsert_relationships(repo_id = repo_id, relationships=repo_graph.relationships)
+        # F-09/F-06: delete + nodes + relationships in one transaction,
+        # serialized per repo by an advisory lock.
+        stats = persistence.persist_graph(
+            repo_id=repo_id,
+            nodes=nodes,
+            relationships=repo_graph.relationships,
+        )
+        logger.info(f"[{ingestion_id}] Graph persisted: {stats}")
 
         # --- Run embeddings via IngestionPipeline ---
         settings = get_settings()

--- a/ingestion_service/src/api/v1/codebase_ingest.py
+++ b/ingestion_service/src/api/v1/codebase_ingest.py
@@ -75,6 +75,67 @@ class RepoIngestResponse(BaseModel):
 
 
 # -----------------------------
+# Batch embedding stage (F-08 / WP-S2)
+# -----------------------------
+def _embed_repo_artifacts(
+    pipeline: IngestionPipeline,
+    persistence: CodebaseGraphPersistence,
+    repo_id: str,
+    ingestion_id: str,
+    nodes: list[dict],
+    provider: str,
+) -> tuple[int, int]:
+    """
+    Chunk every embeddable node, then embed + persist the whole repo in
+    batches: one canonical_id→document_id query, embedder-batched Ollama
+    calls, and /v1/vectors/batch posts of bounded size.
+
+    Returns (chunks_persisted, nodes_skipped_missing_db_record).
+    """
+    canonical_to_document_id = persistence.get_canonical_id_map(repo_id)
+
+    all_chunks = []
+    document_ids: list[str] = []
+    skipped_missing = 0
+
+    for node in nodes:
+        text = node.get("text", "")
+        if not text.strip():
+            logger.debug(f"[{ingestion_id}] Skipping node without text")
+            continue
+
+        canonical_id = node["canonical_id"]
+        document_id = canonical_to_document_id.get(canonical_id)
+        if document_id is None:
+            logger.warning(f"Skipping node without DB record: {canonical_id}")
+            skipped_missing += 1
+            continue
+
+        chunks = pipeline._chunk(text, "code", provider)
+        # Inject canonical_id into every chunk metadata here
+        # This is what extract_canonical_ids_from_chunks() reads in rag_orchestrator
+        for chunk in chunks:
+            chunk.metadata["canonical_id"] = canonical_id
+            chunk.metadata["repo_id"] = repo_id
+            chunk.metadata["relative_path"] = node.get("relative_path", "")
+            chunk.metadata["doc_type"] = node.get("doc_type", "code")
+            chunk.metadata["source_metadata"] = {          # keep source_metadata too
+                **chunk.metadata.get("source_metadata", {}),
+                "canonical_id": canonical_id,
+            }
+
+        all_chunks.extend(chunks)
+        document_ids.extend([document_id] * len(chunks))
+
+    pipeline.embed_and_persist_batch(
+        chunks=all_chunks,
+        ingestion_id=ingestion_id,
+        document_ids=document_ids,
+    )
+    return len(all_chunks), skipped_missing
+
+
+# -----------------------------
 # Background ingestion worker
 # -----------------------------
 def _background_ingest_repo(
@@ -131,37 +192,19 @@ def _background_ingest_repo(
         provider = settings.EMBEDDING_PROVIDER
         pipeline = _build_pipeline(provider)
 
-        # Corrected embedding loop with document_id lookup
-        for node in nodes:
-            logger.debug(f"[{ingestion_id}] Embedding node id={node.get('id')} keys={node.keys()}")
-            text = node.get("text", "")
-            if text.strip():
-                canonical_id = node["canonical_id"]
-
-                # Get the existing document_id from DB using canonical_id
-                doc_node = persistence.get_node_by_canonical_id(repo_id, canonical_id)
-
-                if doc_node:
-                    # Proceed with embedding and persistence
-                    chunks = pipeline._chunk(text, "code", provider)
-                    # Inject canonical_id into every chunk metadata here
-                    # This is what extract_canonical_ids_from_chunks() reads in rag_orchestrator
-                    for chunk in chunks:
-                        chunk.metadata["canonical_id"] = canonical_id
-                        chunk.metadata["repo_id"] = repo_id
-                        chunk.metadata["relative_path"] = node.get("relative_path", "")
-                        chunk.metadata["doc_type"] = node.get("doc_type", "code")
-                        chunk.metadata["source_metadata"] = {          # keep source_metadata too
-                            **chunk.metadata.get("source_metadata", {}),
-                            "canonical_id": canonical_id,
-                        }
-
-                    embeddings = pipeline._embed(chunks)
-                    pipeline._persist(chunks, embeddings, str(ingestion_id), doc_node.document_id)
-                else:
-                    logger.warning(f"Skipping node without DB record: {canonical_id}")
-            else:
-                logger.debug(f"[{ingestion_id}] Skipping node without text")
+        # F-08: batch embedding + persistence (one map query, batched HTTP)
+        chunk_count, skipped_missing = _embed_repo_artifacts(
+            pipeline=pipeline,
+            persistence=persistence,
+            repo_id=repo_id,
+            ingestion_id=str(ingestion_id),
+            nodes=nodes,
+            provider=provider,
+        )
+        logger.info(
+            f"[{ingestion_id}] Embedded {chunk_count} chunks "
+            f"({skipped_missing} nodes had no DB record)"
+        )
 
         StatusManager(session).mark_completed(ingestion_id)
         logger.info(f"✅ Repo ingestion completed: {ingestion_id}")

--- a/ingestion_service/src/core/codebase/codebase_persistence.py
+++ b/ingestion_service/src/core/codebase/codebase_persistence.py
@@ -10,7 +10,10 @@ Requires:
 - RepoGraphBuilder output nodes and relationships
 """
 
-from typing import List, Optional, Tuple
+import uuid
+from typing import List, Optional
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 import logging
@@ -67,158 +70,132 @@ class CodebaseGraphPersistence:
             raise
 
 
-    def upsert_nodes(self, repo_id: str, nodes: List[dict]) -> None:
+    BULK_BATCH_SIZE = 1000
+
+    def persist_graph(
+        self,
+        repo_id: str,
+        nodes: List[dict],
+        relationships: List[dict],
+    ) -> dict:
         """
-        Upsert a list of nodes (functions, classes, modules) into document_nodes.
+        Atomically replace a repo's graph (F-06/F-09, WP-S3).
 
-        Each node dict must include:
-        - relative_path: path relative to repo root
-        - symbol_path: optional symbol path (for functions/methods)
-        - title: display title
-        - doc_type: function/class/module
-        - source: source file path
-        - summary: optional summary
-        """
+        Delete + node insert + relationship insert run in ONE transaction:
+        any failure rolls back everything, leaving the previous graph
+        intact. A transaction-scoped Postgres advisory lock keyed on
+        repo_id serializes concurrent rebuilds of the same repo, so two
+        ingests can never interleave delete/insert (F-11 mitigation).
 
-        # ----------------------
-        # MS12 Repo-Level Deletion
-        # ----------------------
-        try:
-            with self._session.begin():  # atomic transaction
-                deleted_count = (
-                    self._session.query(DocumentNode)
-                    .filter(DocumentNode.repo_id == repo_id)
-                    .delete(synchronize_session=False)
-                )
-                logger.info(f"[MS12] Repo {repo_id}: deleted {deleted_count} old document nodes")
-        except SQLAlchemyError as e:
-            logger.error(f"Failed to delete old nodes for repo {repo_id}: {e}")
-            self._session.rollback()
-            raise
+        Relationship endpoints resolve through the in-memory
+        canonical_id -> document_id map of the nodes being inserted — no
+        per-edge queries. Edges referencing unknown endpoints are skipped
+        (same behavior as before); duplicate edges are absorbed by
+        ON CONFLICT DO NOTHING on uq_document_relationship.
 
-        # ----------------------
-        # Insert New Nodes
-        # ----------------------
-        for node in nodes:
-            try:
-                if "title" not in node:
-                    node["title"] = "Untitled"
-                if "doc_type" not in node:
-                    node["doc_type"] = "unknown"
-                if "source" not in node:
-                    node["source"] = node.get("relative_path", "unknown_source")
-                if "relative_path" not in node:
-                    node["relative_path"] = "Unknown"
-                if "canonical_id" not in node:
-                    node["canonical_id"] = build_canonical_id(node["relative_path"], node.get("symbol_path"))
-                canonical_id = node["canonical_id"]
-                logger.debug(f"upsert_nodes canonical_id = {canonical_id}")
-                document_node_data = {
-                    'repo_id': repo_id,
-                    'canonical_id': canonical_id,
-                    'relative_path': node.get('relative_path', 'unknown'),
-                    'symbol_path': node.get('symbol_path'),
-                    'title': node.get('title', 'Untitled'),
-                    'summary': node.get('summary', ''),
-                    'source': node.get('source', node.get('relative_path', 'unknown')),
-                    'ingestion_id': str(node.get('ingestion_id')),
-                    'doc_type': node.get('doc_type', 'unknown'),
-                    'text': node.get('text', ''),
-                }
-                new_node = DocumentNode(**document_node_data)
-                self._session.add(new_node)
-                logger.debug(f"[MS12] Inserted DocumentNode with canonical_id : {canonical_id}")
+        Node dict fields are the same as the old upsert_nodes contract:
+        relative_path, optional symbol_path/canonical_id, title, doc_type,
+        source, summary, text, ingestion_id.
 
-            except SQLAlchemyError as e:
-                logger.error(f"Error upserting node {node.get('canonical_id', 'unknown')}: {e}")
-                self._session.rollback()
-                raise
-
-        # Commit all inserts
-        try:
-            self._session.commit()
-        except SQLAlchemyError as e:
-            logger.error(f"Error committing new nodes for repo {repo_id}: {e}")
-            self._session.rollback()
-            raise
-
-    # -----------------------------
-    # Document Relationships
-    # -----------------------------
-    def upsert_relationships(self, repo_id: str, relationships: List[dict]) -> None:
-        """
-        Upsert relationships between nodes into document_relationships.
-
-        Expected relationship format:
-
+        Relationship dict format:
         {
             "from_canonical_id": str,
             "to_canonical_id": str,
             "relation_type": str,
             "relationship_metadata": dict
         }
+
+        Returns {"deleted", "nodes", "relationships", "skipped_relationships"}.
         """
+        node_rows: List[dict] = []
+        canonical_to_doc: dict = {}
+        for node in nodes:
+            relative_path = node.get("relative_path", "Unknown")
+            canonical_id = node.get("canonical_id") or build_canonical_id(
+                relative_path, node.get("symbol_path")
+            )
+            document_id = str(uuid.uuid4())
+            canonical_to_doc[canonical_id] = document_id
+            node_rows.append(
+                {
+                    "document_id": document_id,
+                    "repo_id": repo_id,
+                    "canonical_id": canonical_id,
+                    "relative_path": relative_path,
+                    "symbol_path": node.get("symbol_path"),
+                    "title": node.get("title", "Untitled"),
+                    "summary": node.get("summary", ""),
+                    "source": node.get("source", relative_path),
+                    "ingestion_id": str(node.get("ingestion_id")),
+                    "doc_type": node.get("doc_type", "unknown"),
+                    "text": node.get("text", ""),
+                }
+            )
 
+        rel_rows: List[dict] = []
+        skipped_relationships = 0
         for rel in relationships:
-            from_canonical = rel["from_canonical_id"]
-            to_canonical = rel["to_canonical_id"]
+            from_doc = canonical_to_doc.get(rel["from_canonical_id"])
+            to_doc = canonical_to_doc.get(rel["to_canonical_id"])
+            if not from_doc or not to_doc:
+                logger.warning(
+                    f"Skipping relationship: {rel['from_canonical_id']} -> "
+                    f"{rel['to_canonical_id']} (nodes missing)"
+                )
+                skipped_relationships += 1
+                continue
+            rel_rows.append(
+                {
+                    "from_document_id": from_doc,
+                    "to_document_id": to_doc,
+                    "relation_type": rel["relation_type"],
+                    "relationship_metadata": rel.get("relationship_metadata", {}),
+                }
+            )
 
-            try:
-                from_node = (
+        batch = self.BULK_BATCH_SIZE
+        try:
+            with self._session.begin():
+                # Blocks a concurrent rebuild of the same repo until this
+                # transaction commits or rolls back.
+                self._session.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+                    {"key": f"repo_graph:{repo_id}"},
+                )
+                deleted = (
                     self._session.query(DocumentNode)
-                    .filter_by(repo_id=repo_id, canonical_id=from_canonical)
-                    .first()
+                    .filter(DocumentNode.repo_id == repo_id)
+                    .delete(synchronize_session=False)
                 )
-                to_node = (
-                    self._session.query(DocumentNode)
-                    .filter_by(repo_id=repo_id, canonical_id=to_canonical)
-                    .first()
-                )
+                for start in range(0, len(node_rows), batch):
+                    self._session.bulk_insert_mappings(
+                        DocumentNode, node_rows[start:start + batch]
+                    )
+                for start in range(0, len(rel_rows), batch):
+                    stmt = (
+                        pg_insert(DocumentRelationship.__table__)
+                        .values(rel_rows[start:start + batch])
+                        .on_conflict_do_nothing(constraint="uq_document_relationship")
+                    )
+                    self._session.execute(stmt)
+        except SQLAlchemyError:
+            logger.exception(
+                f"Atomic graph persist failed for repo {repo_id}; "
+                f"previous graph left intact"
+            )
+            raise
 
-                if not from_node or not to_node:
-                    logger.warning(
-                        f"Skipping relationship: {from_canonical} -> {to_canonical} (nodes missing)"
-                    )
-                    continue
-
-                existing = (
-                    self._session.query(DocumentRelationship)
-                    .filter_by(
-                        from_document_id=from_node.document_id,
-                        to_document_id=to_node.document_id,
-                        relation_type=rel["relation_type"]
-                    )
-                    .first()
-                )
-
-                if existing:
-                    existing.relationship_metadata = rel.get(
-                        "relationship_metadata",
-                        existing.relationship_metadata
-                    )
-                    logger.debug(
-                        f"Updated DocumentRelationship: {from_canonical} -> {to_canonical}"
-                    )
-                else:
-                    new_rel = DocumentRelationship(
-                        from_document_id=from_node.document_id,
-                        to_document_id=to_node.document_id,
-                        relation_type=rel["relation_type"],
-                        relationship_metadata=rel.get("relationship_metadata", {})
-                    )
-                    self._session.add(new_rel)
-                    logger.debug(
-                        f"Inserted DocumentRelationship: {from_canonical} -> {to_canonical}"
-                    )
-
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"Error upserting relationship {from_canonical} -> {to_canonical}: {e}"
-                )
-                self._session.rollback()
-                raise
-
-        self._session.commit()
+        logger.info(
+            f"Repo {repo_id}: replaced {deleted} old nodes with "
+            f"{len(node_rows)} nodes / {len(rel_rows)} relationships "
+            f"({skipped_relationships} edges skipped)"
+        )
+        return {
+            "deleted": deleted,
+            "nodes": len(node_rows),
+            "relationships": len(rel_rows),
+            "skipped_relationships": skipped_relationships,
+        }
     # -----------------------------
     # Retrieval
     # -----------------------------

--- a/ingestion_service/src/core/codebase/codebase_persistence.py
+++ b/ingestion_service/src/core/codebase/codebase_persistence.py
@@ -232,6 +232,18 @@ class CodebaseGraphPersistence:
             .first()
         )
 
+    def get_canonical_id_map(self, repo_id: str) -> dict:
+        """
+        Return {canonical_id: document_id (str)} for every node in the repo,
+        in a single query (F-08: replaces per-node get_node_by_canonical_id).
+        """
+        rows = (
+            self._session.query(DocumentNode.canonical_id, DocumentNode.document_id)
+            .filter(DocumentNode.repo_id == repo_id)
+            .all()
+        )
+        return {canonical_id: str(document_id) for canonical_id, document_id in rows}
+
     def close(self):
         """Close the session if created internally."""
         if not self._external_session:

--- a/ingestion_service/src/core/http_vectorstore.py
+++ b/ingestion_service/src/core/http_vectorstore.py
@@ -1,6 +1,6 @@
 # ingestion_service/src/core/http_vectorstore.py
 import requests
-from typing import List, Any
+from typing import List, Any, Optional
 import logging
 
 from shared.chunks import Chunk
@@ -17,45 +17,99 @@ class HttpVectorStore:
         self.provider = provider
         logger.debug("ttpVectorStore init")
 
+    PERSIST_BATCH_SIZE = 500
+
+    def _build_record(
+        self,
+        chunk: Chunk,
+        embedding: Any,
+        ingestion_id: str,
+        chunk_index: int,
+        document_id: Optional[str] = None,
+    ) -> dict:
+        metadata_dict = dict(chunk.metadata or {})
+        metadata_dict["chunk_text"] = chunk.content
+
+        record = {
+            "vector": embedding,
+            "metadata": {
+                "ingestion_id": ingestion_id,
+                "chunk_id": chunk.chunk_id,
+                "chunk_index": chunk_index,
+                "chunk_strategy": chunk.metadata.get("chunk_strategy", "unknown"),
+                "chunk_text": chunk.content,
+                "source_metadata": metadata_dict,
+                "provider": chunk.metadata.get("provider", self.provider),
+            },
+        }
+        # MS6-IS2: Add document_id for new vector_chunks path
+        if document_id:
+            record["metadata"]["document_id"] = str(document_id)
+        return record
+
     def persist(
         self,
         chunks: List[Chunk],
         embeddings: List[Any],
         ingestion_id: str,
-        document_id: str = None,  # MS6-IS1: NEW - Link to DocumentNode
+        document_id: Optional[str] = None,  # MS6-IS1: NEW - Link to DocumentNode
     ) -> None:
         """
         Persist chunk embeddings to vector_store_service (vector_chunks table).
         """
         logger.debug("HttpVectorStore persist")
-        records = []
-        for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
-            metadata_dict = dict(chunk.metadata or {})
-            metadata_dict["chunk_text"] = chunk.content
-
-            # Create the record
-            record = {
-                "vector": embedding,
-                "metadata": {
-                    "ingestion_id": ingestion_id,
-                    "chunk_id": chunk.chunk_id,
-                    "chunk_index": i,
-                    "chunk_strategy": chunk.metadata.get("chunk_strategy", "unknown"),
-                    "chunk_text": chunk.content,
-                    "source_metadata": metadata_dict,
-                    "provider": chunk.metadata.get("provider", self.provider),
-                },
-            }
-            logger.debug("HttpVectorStore persist document_id check")
-            # MS6-IS2: Add document_id for new vector_chunks path
-            if document_id:
-                logger.debug("HttpVectorStore persist document_id exists")
-                record["metadata"]["document_id"] = str(document_id)
-
-            records.append(record)
-
+        records = [
+            self._build_record(chunk, embedding, ingestion_id, i, document_id)
+            for i, (chunk, embedding) in enumerate(zip(chunks, embeddings))
+        ]
         self.add_vectors(records)
-        logger.info(f"Persisted {len(records)} vectors for ingestion {ingestion_id}  with document_id  {document_id}")
+        logger.info(
+            f"Persisted {len(records)} vectors for ingestion {ingestion_id} "
+            f"with document_id {document_id}"
+        )
+
+    def persist_batch(
+        self,
+        chunks: List[Chunk],
+        embeddings: List[Any],
+        ingestion_id: str,
+        document_ids: List[str],
+        batch_size: Optional[int] = None,
+    ) -> None:
+        """
+        Persist chunks belonging to many documents in one pass (F-08).
+
+        Each chunk carries its own document_id; records are sent to
+        /v1/vectors/batch in slices of `batch_size` so HTTP round-trips
+        scale with batches, not artifacts. chunk_index restarts per document.
+        """
+        if len(chunks) != len(document_ids):
+            raise ValueError(
+                f"persist_batch mismatch: {len(chunks)} chunks, "
+                f"{len(document_ids)} document_ids"
+            )
+        if batch_size is None:
+            batch_size = self.PERSIST_BATCH_SIZE
+
+        index_by_doc: dict = {}
+        records = []
+        for chunk, embedding, document_id in zip(chunks, embeddings, document_ids):
+            chunk_index = index_by_doc.get(document_id, 0)
+            index_by_doc[document_id] = chunk_index + 1
+            records.append(
+                self._build_record(
+                    chunk, embedding, ingestion_id, chunk_index, document_id
+                )
+            )
+
+        for start in range(0, len(records), batch_size):
+            self.add_vectors(records[start:start + batch_size])
+
+        logger.info(
+            f"Persisted {len(records)} vectors for ingestion {ingestion_id} "
+            f"across {len(index_by_doc)} documents in "
+            f"{-(-len(records) // batch_size) if records else 0} batch(es)"
+        )
 
     def add_vectors(self, records: List[dict]):
         """Send a batch of vectors to vector_store_service."""

--- a/ingestion_service/src/core/pipeline.py
+++ b/ingestion_service/src/core/pipeline.py
@@ -160,6 +160,37 @@ class IngestionPipeline:
         logger.debug(f"📦 MS6 run_with_chunks() Persisting {len(chunks)} chunks with document_id={document_id}")
         self._persist(chunks, embeddings, ingestion_id, str(document_id))
 
+    def embed_and_persist_batch(
+        self,
+        *,
+        chunks: list[Chunk],
+        ingestion_id: str,
+        document_ids: list[str],
+    ) -> None:
+        """
+        Embed pre-chunked artifacts and bulk-persist them (F-08).
+
+        Unlike _persist(), every chunk carries its own document_id, so one
+        call covers a whole repo's artifacts: embeddings happen in embedder
+        batches and persistence goes through the vector store's batch path.
+        """
+        if len(chunks) != len(document_ids):
+            raise ValueError(
+                f"embed_and_persist_batch mismatch: {len(chunks)} chunks, "
+                f"{len(document_ids)} document_ids"
+            )
+        if not chunks:
+            logger.debug("embed_and_persist_batch: no chunks to persist")
+            return
+
+        embeddings = self._embed(chunks)
+        self._vector_store.persist_batch(
+            chunks=chunks,
+            embeddings=embeddings,
+            ingestion_id=ingestion_id,
+            document_ids=document_ids,
+        )
+
     def _validate(self, text: str) -> None:
         """Validate input text (currently no-op)."""
         logger.debug("✅ pipeline.py _validate() - No-op validator passed")

--- a/ingestion_service/tests/codebase/test_atomic_graph_persistence.py
+++ b/ingestion_service/tests/codebase/test_atomic_graph_persistence.py
@@ -1,0 +1,236 @@
+# ingestion_service/tests/codebase/test_atomic_graph_persistence.py
+"""
+F-09/F-06 (WP-S3): transactional, bulk graph persistence + per-repo lock.
+
+Acceptance criteria covered (against docker-compose.test.yml Postgres):
+- a failed rebuild rolls back completely: the previous graph is intact;
+- delete + nodes + relationships commit atomically in one transaction;
+- concurrent rebuilds of the same repo serialize on the advisory lock
+  and can never interleave destructively (final state is exactly one
+  full version, never a mix);
+- persistence is bulk: statement count is constant-ish, not per-edge.
+
+Run with DATABASE_URL pointing at the test DB (localhost:5433), e.g.:
+  DATABASE_URL=postgresql://...@localhost:5433/ingestion_test \
+    ../.venv/Scripts/python.exe -m pytest tests/codebase/ -m integration
+"""
+import threading
+import uuid
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
+
+import src.core.models  # noqa: F401  (register IngestionRequest for FK metadata)
+from shared.models.document_node import DocumentNode
+from shared.models.document_relationship import DocumentRelationship
+from src.core.database_session import get_engine, get_sessionmaker
+from src.core.status_manager import StatusManager
+from src.core.codebase.codebase_persistence import CodebaseGraphPersistence
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+@pytest.fixture(scope="module")
+def ingestion_id():
+    """One ingestion_requests row all test nodes can point at (FK)."""
+    Session = get_sessionmaker()
+    with Session() as s:
+        ing = uuid.uuid4()
+        StatusManager(s).create_request(
+            ingestion_id=ing, source_type="repo", metadata={}
+        )
+        yield str(ing)
+
+
+@pytest.fixture()
+def repo_id():
+    """Fresh repo namespace per test; cleaned up afterwards."""
+    rid = str(uuid.uuid4())
+    yield rid
+    Session = get_sessionmaker()
+    with Session() as s:
+        s.query(DocumentNode).filter_by(repo_id=rid).delete(
+            synchronize_session=False
+        )
+        s.commit()
+
+
+def _nodes(ingestion_id, count, tag):
+    return [
+        {
+            "canonical_id": f"pkg/{tag}{i}.py",
+            "relative_path": f"pkg/{tag}{i}.py",
+            "title": tag,
+            "doc_type": "code",
+            "source": f"pkg/{tag}{i}.py",
+            "summary": "",
+            "text": f"def {tag}{i}(): pass",
+            "ingestion_id": ingestion_id,
+        }
+        for i in range(count)
+    ]
+
+
+def _chain_rels(nodes):
+    return [
+        {
+            "from_canonical_id": a["canonical_id"],
+            "to_canonical_id": b["canonical_id"],
+            "relation_type": "CALL",
+            "relationship_metadata": {},
+        }
+        for a, b in zip(nodes, nodes[1:])
+    ]
+
+
+def _graph_state(repo_id):
+    """Return ({canonical_id: title}, relationship_count) for the repo."""
+    Session = get_sessionmaker()
+    with Session() as s:
+        rows = (
+            s.query(DocumentNode.canonical_id, DocumentNode.title,
+                    DocumentNode.document_id)
+            .filter(DocumentNode.repo_id == repo_id)
+            .all()
+        )
+        doc_ids = [r.document_id for r in rows]
+        rel_count = (
+            s.query(DocumentRelationship)
+            .filter(DocumentRelationship.from_document_id.in_(doc_ids))
+            .count()
+            if doc_ids
+            else 0
+        )
+        return {r.canonical_id: r.title for r in rows}, rel_count
+
+
+def _persist(repo_id, nodes, relationships):
+    Session = get_sessionmaker()
+    with Session() as s:
+        return CodebaseGraphPersistence(session=s).persist_graph(
+            repo_id=repo_id, nodes=nodes, relationships=relationships
+        )
+
+
+# ---------------------------------------------------------------------
+# Atomic commit of nodes + relationships
+# ---------------------------------------------------------------------
+
+def test_persist_graph_round_trip(repo_id, ingestion_id):
+    nodes = _nodes(ingestion_id, 5, "a")
+    rels = _chain_rels(nodes)
+    rels.append(
+        {
+            "from_canonical_id": "pkg/a0.py",
+            "to_canonical_id": "pkg/ghost.py",  # unknown endpoint
+            "relation_type": "CALL",
+            "relationship_metadata": {},
+        }
+    )
+
+    stats = _persist(repo_id, nodes, rels)
+
+    assert stats["nodes"] == 5
+    assert stats["relationships"] == 4
+    assert stats["skipped_relationships"] == 1
+
+    state, rel_count = _graph_state(repo_id)
+    assert set(state) == {f"pkg/a{i}.py" for i in range(5)}
+    assert rel_count == 4
+
+
+def test_rebuild_replaces_previous_graph(repo_id, ingestion_id):
+    _persist(repo_id, _nodes(ingestion_id, 5, "a"), [])
+    v2 = _nodes(ingestion_id, 3, "b")
+    stats = _persist(repo_id, v2, _chain_rels(v2))
+
+    assert stats["deleted"] == 5
+    state, rel_count = _graph_state(repo_id)
+    assert set(state) == {f"pkg/b{i}.py" for i in range(3)}
+    assert rel_count == 2
+
+
+def test_failed_rebuild_preserves_previous_graph(repo_id, ingestion_id):
+    v1 = _nodes(ingestion_id, 4, "a")
+    _persist(repo_id, v1, _chain_rels(v1))
+
+    poisoned = _nodes(ingestion_id, 3, "b")
+    poisoned.append(dict(poisoned[0]))  # duplicate canonical_id -> uq violation
+
+    with pytest.raises(IntegrityError):
+        _persist(repo_id, poisoned, [])
+
+    state, rel_count = _graph_state(repo_id)
+    assert set(state) == {f"pkg/a{i}.py" for i in range(4)}, (
+        "failed rebuild must leave the previous graph intact"
+    )
+    assert rel_count == 3
+
+
+# ---------------------------------------------------------------------
+# Per-repo advisory lock: concurrent rebuilds never interleave
+# ---------------------------------------------------------------------
+
+def test_concurrent_rebuilds_never_interleave(repo_id, ingestion_id):
+    version_a = _nodes(ingestion_id, 6, "a")
+    version_b = _nodes(ingestion_id, 9, "b")
+    errors = []
+
+    def worker(nodes):
+        try:
+            _persist(repo_id, nodes, _chain_rels(nodes))
+        except Exception as exc:  # noqa: BLE001 - recorded for the assert
+            errors.append(exc)
+
+    for _ in range(3):  # repeat to give interleaving a chance
+        barrier = threading.Barrier(2)
+
+        def run(nodes):
+            barrier.wait()
+            worker(nodes)
+
+        threads = [
+            threading.Thread(target=run, args=(version_a,)),
+            threading.Thread(target=run, args=(version_b,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, errors
+        state, rel_count = _graph_state(repo_id)
+        titles = set(state.values())
+        assert titles in ({"a"}, {"b"}), f"interleaved graph: {state}"
+        if titles == {"a"}:
+            assert len(state) == 6 and rel_count == 5
+        else:
+            assert len(state) == 9 and rel_count == 8
+
+
+# ---------------------------------------------------------------------
+# Bulk persistence: statements scale with batches, not edges
+# ---------------------------------------------------------------------
+
+def test_persist_graph_statement_count_is_bulk(repo_id, ingestion_id):
+    nodes = _nodes(ingestion_id, 50, "a")
+    rels = _chain_rels(nodes)  # 49 edges
+    statements = []
+
+    def counter(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    engine = get_engine()
+    event.listen(engine, "before_cursor_execute", counter)
+    try:
+        _persist(repo_id, nodes, rels)
+    finally:
+        event.remove(engine, "before_cursor_execute", counter)
+
+    # lock + delete + 1 node batch + 1 relationship batch (+ session noise);
+    # the old path issued 3 statements per edge (~150 here).
+    assert len(statements) <= 10, (
+        f"{len(statements)} statements for 50 nodes / 49 edges:\n"
+        + "\n".join(statements[:20])
+    )

--- a/ingestion_service/tests/codebase/test_batch_embedding.py
+++ b/ingestion_service/tests/codebase/test_batch_embedding.py
@@ -1,0 +1,292 @@
+# ingestion_service/tests/codebase/test_batch_embedding.py
+"""
+F-08 (WP-S2): batch embedding + persistence.
+
+Acceptance criteria covered:
+- vector-store HTTP calls scale with batches, not artifacts:
+  ingesting N chunks issues ceil(N/500) POSTs to /v1/vectors/batch,
+  asserted via a request counter on a test double;
+- exactly one canonical_id -> document_id query per repo ingest
+  (per-node get_node_by_canonical_id is no longer called);
+- OllamaEmbedder honors batch_size: one /api/embed POST per batch,
+  order of embeddings preserved across batches.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from shared.chunks import Chunk
+from shared.embedders.ollama import OllamaEmbedder
+from src.core.http_vectorstore import HttpVectorStore
+from src.core.pipeline import IngestionPipeline
+from src.api.v1.codebase_ingest import _embed_repo_artifacts
+
+pytestmark = pytest.mark.unit
+
+
+def _make_chunks(n: int) -> list[Chunk]:
+    return [Chunk(chunk_id=f"c{i}", content=f"text {i}") for i in range(n)]
+
+
+# ---------------------------------------------------------------------
+# OllamaEmbedder batching
+# ---------------------------------------------------------------------
+
+def _ollama_response(texts_per_call):
+    """Build a fake requests.post that echoes one embedding per input."""
+    def fake_post(url, json=None, **kwargs):
+        texts_per_call.append(list(json["input"]))
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "embeddings": [[float(len(t))] for t in json["input"]]
+        }
+        return resp
+    return fake_post
+
+
+def test_ollama_embedder_splits_into_batches():
+    calls: list[list[str]] = []
+    embedder = OllamaEmbedder(base_url="http://x", model="m", batch_size=50)
+    chunks = _make_chunks(120)
+
+    with patch(
+        "shared.embedders.ollama.requests.post", side_effect=_ollama_response(calls)
+    ):
+        embeddings = embedder.embed(chunks)
+
+    assert [len(c) for c in calls] == [50, 50, 20]
+    assert len(embeddings) == 120
+    # order preserved: embedding i encodes len("text i")
+    assert embeddings[0] == [float(len("text 0"))]
+    assert embeddings[119] == [float(len("text 119"))]
+
+
+def test_ollama_embedder_single_batch_when_small():
+    calls: list[list[str]] = []
+    embedder = OllamaEmbedder(base_url="http://x", model="m", batch_size=50)
+
+    with patch(
+        "shared.embedders.ollama.requests.post", side_effect=_ollama_response(calls)
+    ):
+        embeddings = embedder.embed(_make_chunks(3))
+
+    assert len(calls) == 1
+    assert len(embeddings) == 3
+
+
+def test_ollama_embedder_empty_input_no_http():
+    embedder = OllamaEmbedder(base_url="http://x", model="m", batch_size=50)
+    with patch("shared.embedders.ollama.requests.post") as post:
+        assert embedder.embed([]) == []
+    post.assert_not_called()
+
+
+def test_ollama_embedder_count_mismatch_raises():
+    def bad_post(url, json=None, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"embeddings": [[1.0]]}  # always one
+        return resp
+
+    embedder = OllamaEmbedder(base_url="http://x", model="m", batch_size=50)
+    with patch("shared.embedders.ollama.requests.post", side_effect=bad_post):
+        with pytest.raises(RuntimeError):
+            embedder.embed(_make_chunks(2))
+
+
+# ---------------------------------------------------------------------
+# HttpVectorStore.persist_batch
+# ---------------------------------------------------------------------
+
+def test_persist_batch_slices_http_calls():
+    store = HttpVectorStore(base_url="http://vs")
+    batches: list[list[dict]] = []
+    store.add_vectors = lambda records: batches.append(records)
+
+    n = 1200
+    chunks = _make_chunks(n)
+    embeddings = [[0.0]] * n
+    document_ids = [f"doc-{i % 7}" for i in range(n)]
+
+    store.persist_batch(chunks, embeddings, "ing-1", document_ids)
+
+    assert [len(b) for b in batches] == [500, 500, 200]
+
+
+def test_persist_batch_per_chunk_document_id_and_index():
+    store = HttpVectorStore(base_url="http://vs")
+    batches: list[list[dict]] = []
+    store.add_vectors = lambda records: batches.append(records)
+
+    chunks = _make_chunks(4)
+    document_ids = ["doc-a", "doc-a", "doc-b", "doc-a"]
+    store.persist_batch(chunks, [[0.0]] * 4, "ing-1", document_ids)
+
+    records = [r for b in batches for r in b]
+    assert [r["metadata"]["document_id"] for r in records] == document_ids
+    # chunk_index restarts per document
+    assert [r["metadata"]["chunk_index"] for r in records] == [0, 1, 0, 2]
+    assert all(r["metadata"]["ingestion_id"] == "ing-1" for r in records)
+
+
+def test_persist_batch_length_mismatch_raises():
+    store = HttpVectorStore(base_url="http://vs")
+    with pytest.raises(ValueError):
+        store.persist_batch(_make_chunks(2), [[0.0]] * 2, "ing-1", ["doc-a"])
+
+
+def test_persist_batch_empty_no_http():
+    store = HttpVectorStore(base_url="http://vs")
+    calls = []
+    store.add_vectors = lambda records: calls.append(records)
+    store.persist_batch([], [], "ing-1", [])
+    assert calls == []
+
+
+# ---------------------------------------------------------------------
+# _embed_repo_artifacts: whole-repo batch stage
+# ---------------------------------------------------------------------
+
+class CountingPersistence:
+    """Test double: one map query allowed, per-node lookups forbidden."""
+
+    def __init__(self, mapping: dict):
+        self.mapping = mapping
+        self.map_queries = 0
+
+    def get_canonical_id_map(self, repo_id: str) -> dict:
+        self.map_queries += 1
+        return dict(self.mapping)
+
+    def get_node_by_canonical_id(self, repo_id, canonical_id):
+        raise AssertionError(
+            "per-node get_node_by_canonical_id must not be called (F-08)"
+        )
+
+
+class FakeEmbedder:
+    def __init__(self):
+        self.calls = 0
+
+    def embed(self, chunks):
+        self.calls += 1
+        return [[0.0]] * len(chunks)
+
+
+class NoOpValidator:
+    def validate(self, text):
+        return None
+
+
+def _make_nodes(n: int) -> list[dict]:
+    return [
+        {
+            "canonical_id": f"pkg/mod{i}.py",
+            "relative_path": f"pkg/mod{i}.py",
+            "doc_type": "code",
+            "text": f"def f{i}():\n    return {i}\n",
+        }
+        for i in range(n)
+    ]
+
+
+def _run_stage(nodes, mapping, batch_size=500):
+    store = HttpVectorStore(base_url="http://vs")
+    http_calls: list[int] = []
+    store.add_vectors = lambda records: http_calls.append(len(records))
+    store.PERSIST_BATCH_SIZE = batch_size  # instance attr shadows class default
+
+    embedder = FakeEmbedder()
+    pipeline = IngestionPipeline(
+        validator=NoOpValidator(), embedder=embedder, vector_store=store
+    )
+    persistence = CountingPersistence(mapping)
+
+    counts = _embed_repo_artifacts(
+        pipeline=pipeline,
+        persistence=persistence,
+        repo_id="repo-1",
+        ingestion_id="ing-1",
+        nodes=nodes,
+        provider="mock",
+    )
+    return counts, persistence, embedder, http_calls
+
+
+def test_embed_repo_artifacts_batches_and_single_map_query():
+    nodes = _make_nodes(30)
+    mapping = {n["canonical_id"]: f"doc-{i}" for i, n in enumerate(nodes)}
+
+    (chunk_count, skipped), persistence, embedder, http_calls = _run_stage(
+        nodes, mapping
+    )
+
+    assert persistence.map_queries == 1
+    assert embedder.calls == 1  # one embed pass over all chunks
+    assert skipped == 0
+    assert chunk_count >= 30  # at least one chunk per node
+    # N chunks -> ceil(N/500) HTTP calls; 30 small nodes fit in one
+    assert len(http_calls) == 1
+    assert sum(http_calls) == chunk_count
+
+
+def test_embed_repo_artifacts_http_calls_scale_with_batches():
+    nodes = _make_nodes(25)
+    mapping = {n["canonical_id"]: f"doc-{i}" for i, n in enumerate(nodes)}
+
+    # force tiny persist batches to observe slicing without 500+ nodes
+    (chunk_count, _), _, _, http_calls = _run_stage(nodes, mapping, batch_size=10)
+
+    expected_calls = -(-chunk_count // 10)  # ceil
+    assert len(http_calls) == expected_calls
+    assert sum(http_calls) == chunk_count
+
+
+def test_embed_repo_artifacts_skips_textless_and_unmapped_nodes():
+    nodes = _make_nodes(3)
+    nodes.append({"canonical_id": "pkg/empty.py", "text": "   "})
+    nodes.append(
+        {
+            "canonical_id": "pkg/ghost.py",
+            "relative_path": "pkg/ghost.py",
+            "doc_type": "code",
+            "text": "def g():\n    return 0\n",
+        }
+    )
+    mapping = {n["canonical_id"]: f"doc-{i}" for i, n in enumerate(nodes[:3])}
+
+    (chunk_count, skipped), _, embedder, http_calls = _run_stage(nodes, mapping)
+
+    assert skipped == 1  # ghost.py had no DB record
+    assert chunk_count >= 3
+    assert sum(http_calls) == chunk_count
+
+
+def test_embed_repo_artifacts_injects_canonical_metadata():
+    nodes = _make_nodes(2)
+    mapping = {n["canonical_id"]: f"doc-{i}" for i, n in enumerate(nodes)}
+
+    store = HttpVectorStore(base_url="http://vs")
+    received: list[dict] = []
+    store.add_vectors = lambda records: received.extend(records)
+
+    pipeline = IngestionPipeline(
+        validator=NoOpValidator(), embedder=FakeEmbedder(), vector_store=store
+    )
+    _embed_repo_artifacts(
+        pipeline=pipeline,
+        persistence=CountingPersistence(mapping),
+        repo_id="repo-1",
+        ingestion_id="ing-1",
+        nodes=nodes,
+        provider="mock",
+    )
+
+    assert received
+    for record in received:
+        meta = record["metadata"]["source_metadata"]
+        assert meta["repo_id"] == "repo-1"
+        assert meta["canonical_id"] in mapping
+        assert record["metadata"]["document_id"] == mapping[meta["canonical_id"]]
+        assert meta["source_metadata"]["canonical_id"] == meta["canonical_id"]

--- a/shared/embedders/ollama.py
+++ b/shared/embedders/ollama.py
@@ -51,25 +51,31 @@ class OllamaEmbedder(BaseEmbedder):
         )
 
         texts = [_truncate(chunk.content) for chunk in chunks]
+        if not texts:
+            return []
 
+        embeddings: List[List[float]] = []
         try:
-            payload = {"model": self.model, "input": texts}
+            for start in range(0, len(texts), self.batch_size):
+                batch = texts[start:start + self.batch_size]
+                payload = {"model": self.model, "input": batch}
 
-            response = requests.post(f"{self.base_url}/api/embed", json=payload)
+                response = requests.post(f"{self.base_url}/api/embed", json=payload)
 
-            if response.status_code != 200:
-                raise RuntimeError(
-                    f"Ollama embedding failed "
-                    f"(status={response.status_code}): {response.text}"
-                )
+                if response.status_code != 200:
+                    raise RuntimeError(
+                        f"Ollama embedding failed "
+                        f"(status={response.status_code}): {response.text}"
+                    )
 
-            result = response.json()
-
-            return (
-                result.get("embeddings", [result["embeddings"]])
-                if isinstance(texts, list)
-                else [result["embeddings"]]
-            )
+                embeddings.extend(response.json()["embeddings"])
 
         except Exception as e:
             raise RuntimeError(f"Ollama embedder error: {e}") from e
+
+        if len(embeddings) != len(texts):
+            raise RuntimeError(
+                f"Ollama returned {len(embeddings)} embeddings "
+                f"for {len(texts)} inputs"
+            )
+        return embeddings


### PR DESCRIPTION
## Summary

Two audit-remediation slices from DOCS/audit/04-Scalability-Plan.md, as separate commits:

**F-08 (WP-S2) — batch embedding + persistence** (43a7232)
- One canonical_id→document_id query per repo replaces the per-node SQL lookup
- OllamaEmbedder now honors OLLAMA_BATCH_SIZE (one /api/embed POST per 50 chunks)
- New HttpVectorStore.persist_batch: per-chunk document_id, /v1/vectors/batch in slices of 500
- New IngestionPipeline.embed_and_persist_batch; ingest loop refactored into testable _embed_repo_artifacts

**F-09/F-06 (WP-S3) — atomic bulk graph persistence + per-repo lock** (7a882a5)
- persist_graph(): delete + bulk node insert + bulk relationship insert in ONE transaction (failure rolls back, previous graph intact)
- Relationship endpoints resolved via in-memory map (was 3 queries/edge); ON CONFLICT DO NOTHING on uq_document_relationship
- pg_advisory_xact_lock keyed on repo_id serializes concurrent rebuilds of the same repo

## Testing
- 12 new unit tests (batch counts asserted via request counters on test doubles)
- 5 new integration tests against docker-compose.test.yml Postgres: rollback-preserves-graph, atomic replace, 3 rounds of concurrent rebuilds never interleave, ≤10 SQL statements for 50 nodes + 49 edges
- Unit suite: 73 passed, 1 pre-existing skip (3 files excluded per #25)
- End-to-end on rebuilt stack: /app/shared ingest completed; 209→210 nodes replaced atomically, 178 edges, 133 chunks across 48 documents
- Full results recorded in DOCS/test_results/F-08-F-09-batch-atomic-persistence.md

No changes to graph semantics, canonical identity, embedding model, vector dimensions, API contracts, or language support.