### PR TITLE
Issue #30: RAG query-path fixes (all five parts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,12 @@ jobs:
 
       - name: rag_orchestrator tests
         working-directory: rag_orchestrator
-        # Explicit files: tests/__init__.py is a directory that breaks
-        # collection of the files inside it (issue #24)
+        # tests/__init__.py is a directory that breaks collection of the
+        # files inside it (issue #24); --ignore it so new test files are
+        # still collected automatically
         run: >
           ../.venv/bin/python -m pytest -q
-          tests/test_multi_seed_traversal.py
-          tests/test_imports_traversal.py
+          --ignore=tests/__init__.py
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/DOCS/architecture/Repo-query-ascii-flow-diagram.md
+++ b/DOCS/architecture/Repo-query-ascii-flow-diagram.md
@@ -109,7 +109,7 @@
 │               → expanded_canonical_ids                                                    │
 │                                                                                           │
 │  STEP 6: RESOLVE ALL CANONICAL IDS → DOCUMENT IDS                                        │
-│  canonical_ids_to_document_ids_http(repo_id, seed_cids ∪ expanded_cids) [service.py]    │
+│  canonical_to_document_map_http(repo_id, seed_cids ∪ expanded_cids) [service.py]        │
 │       └── GET ingestion_service:8001/v1/graph/repos/{repo_id}/nodes                      │
 │               params: canonical_ids=cid1,cid2,...                                         │
 │               │                                                                            │

--- a/ingestion_service/src/api/v1/codebase_ingest.py
+++ b/ingestion_service/src/api/v1/codebase_ingest.py
@@ -19,6 +19,7 @@ from src.core.config import get_settings
 from shared.embedders.factory import get_embedder
 from src.core.http_vectorstore import HttpVectorStore
 from src.core.codebase.identity import build_repo_id
+from src.core.repo_naming import derive_repo_identity
 # -----------------------------
 # Session and router
 # -----------------------------
@@ -234,11 +235,18 @@ def ingest_repo(
         raise HTTPException(status_code=400, detail="Must provide either git_url or local_path")
 
     ingestion_id = uuid4()
+    metadata = {"git_url": git_url, "local_path": local_path, "provider": provider}
+    # Issue #30 Part 5: persist the derived display identity alongside the
+    # raw source so it stays queryable; derivation lives in repo_naming.
+    identity = derive_repo_identity(metadata)
+    metadata.update(
+        {k: identity[k] for k in ("source_type", "name", "display_name")}
+    )
     with SessionLocal() as session:
         StatusManager(session).create_request(
             ingestion_id=ingestion_id,
             source_type="repo",
-            metadata={"git_url": git_url, "local_path": local_path, "provider": provider},
+            metadata=metadata,
         )
 
     # Fire-and-forget background ingestion

--- a/ingestion_service/src/api/v1/repos.py
+++ b/ingestion_service/src/api/v1/repos.py
@@ -1,11 +1,12 @@
 # ingestion_service/src/api/v1/repos.py
 
 from fastapi import APIRouter
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime
 
 from src.core import db_utils
+from src.core.repo_naming import derive_repo_identity
 
 #router = APIRouter(prefix="/v1", tags=["repos"])
 router = APIRouter(tags=["repos"])
@@ -20,6 +21,37 @@ class RepoSummary(BaseModel):
     ingested_at: datetime
     file_count: int
     node_count: int
+    source_type: Optional[str] = None
+    git_url: Optional[str] = None
+    local_path: Optional[str] = None
+    branch: Optional[str] = None
+
+
+def build_repo_summary(row: dict) -> RepoSummary:
+    """
+    Map one list_complete_repos() row to a RepoSummary, deriving real
+    names from ingestion metadata (issue #30 Part 5). UUID-derived labels
+    remain only as last-resort fallback for rows without usable metadata.
+    """
+    repo_id = str(row["repo_id"])
+    short_id = repo_id[:8]
+
+    identity = derive_repo_identity(row.get("ingestion_metadata"))
+
+    return RepoSummary(
+        id=repo_id,
+        name=identity["name"] or f"repo-{short_id}",
+        display_name=identity["display_name"] or f"Repository {short_id}",
+        status=row["status"],
+        ingestion_id=str(row["ingestion_id"]),
+        ingested_at=row["created_at"],
+        file_count=row["file_count"],
+        node_count=row["node_count"],
+        source_type=identity["source_type"],
+        git_url=identity["git_url"],
+        local_path=identity["local_path"],
+        branch=identity["branch"],
+    )
 
 
 @router.get("/repos", response_model=List[RepoSummary])
@@ -29,28 +61,7 @@ async def list_repos():
     """
     repo_rows = db_utils.list_complete_repos()
 
-    result: List[RepoSummary] = []
-
-    for row in repo_rows:
-        repo_id = str(row["repo_id"])
-        ingestion_id = row["ingestion_id"]
-        status = row["status"]
-        created_at = row["created_at"]
-
-        short_id = repo_id[:8]
-
-        result.append(
-            RepoSummary(
-                id=repo_id,
-                name=f"repo-{short_id}",
-                display_name=f"Repository {short_id}",
-                status=status,
-                ingestion_id=str(ingestion_id),
-                ingested_at=created_at,
-                file_count=row["file_count"],
-                node_count=row["node_count"],
-            )
-        )
+    result = [build_repo_summary(row) for row in repo_rows]
 
     # Sort newest first
     result.sort(key=lambda r: r.ingested_at, reverse=True)

--- a/ingestion_service/src/core/db_utils.py
+++ b/ingestion_service/src/core/db_utils.py
@@ -112,6 +112,7 @@ def list_complete_repos() -> List[Dict]:
         created_at
         file_count
         node_count
+        ingestion_metadata
     """
     with SessionLocal() as session:
 
@@ -138,6 +139,19 @@ def list_complete_repos() -> List[Dict]:
 
         results: List[Dict] = []
 
+        # JSON columns can't be grouped in Postgres, so fetch the
+        # ingestion metadata (git_url/local_path/…) in a second query
+        # keyed by the already-grouped ingestion_ids (issue #30 Part 5).
+        ingestion_ids = [row[1] for row in repo_rows]
+        metadata_by_ingestion = dict(
+            session.query(
+                IngestionRequest.ingestion_id,
+                IngestionRequest.ingestion_metadata,
+            )
+            .filter(IngestionRequest.ingestion_id.in_(ingestion_ids))
+            .all()
+        ) if ingestion_ids else {}
+
         for repo_id, ingestion_id, status, created_at in repo_rows:
 
             node_count = (
@@ -160,6 +174,7 @@ def list_complete_repos() -> List[Dict]:
                     "created_at": created_at,
                     "file_count": int(file_count or 0),
                     "node_count": int(node_count or 0),
+                    "ingestion_metadata": metadata_by_ingestion.get(ingestion_id),
                 }
             )
 

--- a/ingestion_service/src/core/repo_naming.py
+++ b/ingestion_service/src/core/repo_naming.py
@@ -1,0 +1,95 @@
+# ingestion_service/src/core/repo_naming.py
+"""
+Derive human-readable repository identity from ingestion metadata.
+
+Issue #30 Part 5: /v1/ingest-repo already persists {git_url, local_path,
+provider} in IngestionRequest.ingestion_metadata; this module turns that
+into name/display_name instead of the UUID-derived labels. Works for
+historical rows too — everything is recomputed from git_url/local_path.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import PureWindowsPath
+from typing import Any, Dict, Optional, Tuple
+
+
+def _parse_git_url(url: str) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Return (owner, name) from a git URL, or (None, None) if unparseable.
+
+    Handles https://host/owner/repo(.git), scp-style
+    git@host:owner/repo(.git), ssh://git@host/owner/repo, and trailing
+    slashes. Owner is the second-to-last path segment when present.
+    """
+    cleaned = url.strip().rstrip("/")
+    if cleaned.lower().endswith(".git"):
+        cleaned = cleaned[:-4]
+
+    scp_match = re.match(r"^[\w.+-]+@[\w.-]+:(.+)$", cleaned)
+    scheme_match = re.match(r"^[a-zA-Z][\w+.-]*://[^/]+/(.+)$", cleaned)
+    if scp_match:
+        path = scp_match.group(1)
+    elif scheme_match:
+        path = scheme_match.group(1)
+    else:
+        return None, None
+
+    segments = [s for s in path.split("/") if s]
+    if not segments:
+        return None, None
+
+    name = segments[-1]
+    owner = segments[-2] if len(segments) >= 2 else None
+    return owner, name
+
+
+def derive_repo_identity(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Map ingestion metadata to display identity.
+
+    Returns a dict with keys source_type, name, display_name, git_url,
+    local_path, branch. name/display_name are None when identity cannot
+    be derived — callers fall back to UUID-derived labels.
+    """
+    metadata = metadata or {}
+    git_url = metadata.get("git_url")
+    local_path = metadata.get("local_path")
+    branch = metadata.get("branch")
+
+    if git_url:
+        owner, name = _parse_git_url(git_url)
+        display_name = None
+        if name:
+            display_name = f"{owner}/{name}" if owner else name
+        return {
+            "source_type": "git",
+            "name": name,
+            "display_name": display_name,
+            "git_url": git_url,
+            "local_path": None,
+            "branch": branch,
+        }
+
+    if local_path:
+        # PureWindowsPath accepts both / and \ separators, so this also
+        # handles posix-style paths recorded by dockerized ingests.
+        name = PureWindowsPath(str(local_path).rstrip("/\\")).name or None
+        display_name = f"{name} — {local_path}" if name else None
+        return {
+            "source_type": "local",
+            "name": name,
+            "display_name": display_name,
+            "git_url": None,
+            "local_path": local_path,
+            "branch": branch,
+        }
+
+    return {
+        "source_type": None,
+        "name": None,
+        "display_name": None,
+        "git_url": None,
+        "local_path": None,
+        "branch": branch,
+    }

--- a/ingestion_service/tests/core/test_repo_naming.py
+++ b/ingestion_service/tests/core/test_repo_naming.py
@@ -1,0 +1,91 @@
+# ingestion_service/tests/core/test_repo_naming.py
+"""
+Issue #30 Part 5: repository names derive from ingestion metadata
+(git_url / local_path), not from the repo UUID.
+"""
+import pytest
+
+from src.core.repo_naming import derive_repo_identity
+
+pytestmark = pytest.mark.unit
+
+
+def test_https_url_with_git_suffix():
+    identity = derive_repo_identity(
+        {"git_url": "https://github.com/sankar-ramamoorthy/rag-foundry-universal.git"}
+    )
+    assert identity["source_type"] == "git"
+    assert identity["name"] == "rag-foundry-universal"
+    assert identity["display_name"] == "sankar-ramamoorthy/rag-foundry-universal"
+    assert identity["git_url"].startswith("https://")
+    assert identity["local_path"] is None
+
+
+def test_https_url_without_git_suffix_and_trailing_slash():
+    identity = derive_repo_identity({"git_url": "https://github.com/owner/repo/"})
+    assert identity["name"] == "repo"
+    assert identity["display_name"] == "owner/repo"
+
+
+def test_scp_style_ssh_url():
+    identity = derive_repo_identity({"git_url": "git@github.com:owner/repo.git"})
+    assert identity["source_type"] == "git"
+    assert identity["name"] == "repo"
+    assert identity["display_name"] == "owner/repo"
+
+
+def test_ssh_scheme_url():
+    identity = derive_repo_identity({"git_url": "ssh://git@gitlab.com/group/project.git"})
+    assert identity["name"] == "project"
+    assert identity["display_name"] == "group/project"
+
+
+def test_same_repo_name_different_owners_stay_distinguishable():
+    a = derive_repo_identity({"git_url": "https://github.com/alice/tool.git"})
+    b = derive_repo_identity({"git_url": "https://github.com/bob/tool.git"})
+    assert a["name"] == b["name"] == "tool"
+    assert a["display_name"] != b["display_name"]
+
+
+def test_windows_local_path():
+    identity = derive_repo_identity({"local_path": "C:\\Users\\bosto\\repos\\my_test_repo"})
+    assert identity["source_type"] == "local"
+    assert identity["name"] == "my_test_repo"
+    assert identity["display_name"] == "my_test_repo — C:\\Users\\bosto\\repos\\my_test_repo"
+    assert identity["git_url"] is None
+
+
+def test_posix_local_path_with_trailing_slash():
+    identity = derive_repo_identity({"local_path": "/data/repos/my_repo/"})
+    assert identity["name"] == "my_repo"
+    assert identity["local_path"] == "/data/repos/my_repo/"
+
+
+def test_git_url_wins_over_local_path():
+    identity = derive_repo_identity(
+        {"git_url": "https://github.com/o/r.git", "local_path": "/tmp/clone"}
+    )
+    assert identity["source_type"] == "git"
+    assert identity["name"] == "r"
+
+
+def test_unparseable_git_url_falls_back_to_none():
+    identity = derive_repo_identity({"git_url": "not a url"})
+    assert identity["source_type"] == "git"
+    assert identity["name"] is None
+    assert identity["display_name"] is None
+
+
+def test_missing_metadata_yields_all_none():
+    for metadata in (None, {}, {"provider": "ollama"}):
+        identity = derive_repo_identity(metadata)
+        assert identity["source_type"] is None
+        assert identity["name"] is None
+        assert identity["display_name"] is None
+
+
+def test_branch_passthrough():
+    identity = derive_repo_identity(
+        {"git_url": "https://github.com/o/r.git", "branch": "develop"}
+    )
+    assert identity["branch"] == "develop"

--- a/rag_orchestrator/src/api/v1/routes.py
+++ b/rag_orchestrator/src/api/v1/routes.py
@@ -36,18 +36,18 @@ async def rag_endpoint(rag_query: RAGQuery):
     logger.debug(f"Received RAG query: {rag_query}")
 
     try:
-        # Call the service layer to perform the full RAG process
-        #result = await run_rag(
-        #    rag_query.query, rag_query.top_k, rag_query.provider, rag_query.model
-        #)
         result = await run_rag(
         query=rag_query.query,
+        repo_id=rag_query.repo_id,
         top_k=rag_query.top_k,
         provider=rag_query.provider,
         model=rag_query.model
         )
         return result
 
+    except HTTPException:
+        # Preserve service-layer status codes (e.g. 404 unknown repo_id)
+        raise
     except Exception as e:
         logger.error(f"Error occurred during the RAG process: {e}")
         raise HTTPException(

--- a/rag_orchestrator/src/core/config.py
+++ b/rag_orchestrator/src/core/config.py
@@ -17,6 +17,20 @@ class Settings(BaseSettings):
     OLLAMA_BATCH_SIZE: int = 50
 
     # -------------------------------------------------
+    # Retrieval expansion limits (issue #30 Part 3)
+    # -------------------------------------------------
+    # Cap on graph-expanded documents fetched per query; ranked expanded
+    # docs beyond this are reported as considered-but-unused.
+    MAX_EXPANDED_DOCS: int = 20
+    # Chunks fetched per expanded doc — expansion is context, not the
+    # primary hit, so this stays well below the seed top_k.
+    EXPANDED_DOC_CHUNKS: int = 3
+    # Overall chunk cap handed to the agent adapter (was 9999).
+    MAX_TOTAL_CHUNKS: int = 50
+    # Concurrency of search-by-doc fetches for expanded docs.
+    MAX_CONCURRENT_DOC_FETCHES: int = 8
+
+    # -------------------------------------------------
     # Service URLs (Docker service names)
     # -------------------------------------------------
     VECTOR_STORE_URL: str = "http://vector_store_service:8002"

--- a/rag_orchestrator/src/core/service.py
+++ b/rag_orchestrator/src/core/service.py
@@ -133,13 +133,16 @@ async def hybrid_retrieve(
 
     search_url = f"{settings.VECTOR_STORE_URL}/v1/vectors/search"
     payload = {"query_vector": query_embedding, "k": top_k,
-                "metadata_filter": {"doc_type": "code"}}
+                "metadata_filter": {"doc_type": "code", "repo_id": repo_id}}
 
     async with httpx.AsyncClient(timeout=200) as client:
         resp = await client.post(search_url, json=payload)
         if resp.status_code != 200 or not resp.json().get("results"):
-            logger.info("No code chunks found. Falling back to general search.")
-            payload.pop("metadata_filter", None)
+            logger.info("No code chunks found. Falling back to repo-scoped search.")
+            # Relax only doc_type — the fallback must never leave the repo,
+            # or queries against repos with no code chunks silently answer
+            # from other repos (issue #30 Part 1).
+            payload["metadata_filter"] = {"repo_id": repo_id}
             resp = await client.post(search_url, json=payload)
         resp.raise_for_status()
         raw_results = resp.json().get("results", [])

--- a/rag_orchestrator/src/core/service.py
+++ b/rag_orchestrator/src/core/service.py
@@ -14,7 +14,10 @@ from shared.embedders.factory import get_embedder
 
 from shared.retrieval.retrieval_plan import RetrievalPlan
 from rag_orchestrator.src.retrieval.execute_plan import execute_retrieval_plan
-from rag_orchestrator.src.retrieval.agent_adapter import prepare_chunks_for_agent
+from rag_orchestrator.src.retrieval.agent_adapter import (
+    build_sources,
+    prepare_chunks_for_agent,
+)
 from rag_orchestrator.src.retrieval.types import RetrievedChunk
 
 from rag_orchestrator.src.retrieval.codebase_utils import extract_canonical_ids_from_chunks
@@ -295,7 +298,8 @@ async def run_rag(
         resp.raise_for_status()
         result = resp.json()
 
-    sources = [c["document_id"] for c in agent_chunks]
+    # Issue #30 Part 4: canonical IDs / paths, deduplicated, seeds first
+    sources = build_sources(agent_chunks)
 
     return RAGResult(
         answer=result.get("response", ""),

--- a/rag_orchestrator/src/core/service.py
+++ b/rag_orchestrator/src/core/service.py
@@ -1,6 +1,7 @@
 # rag_orchestrator/src/core/service.py
 # ADR-045 Hybrid Vector + Graph RAG (HTTP-only, clean boundaries)
 
+import asyncio
 import logging
 from typing import List, Optional, Callable, Dict, Any, Set, cast
 import httpx
@@ -81,15 +82,18 @@ async def resolve_repo_id_http(repo_id: Optional[str]) -> str:
 # GRAPH API: canonical_ids → document_ids
 # ------------------------------------------------------------------
 
-async def canonical_ids_to_document_ids_http(
+async def canonical_to_document_map_http(
     repo_id: str,
     canonical_ids: Set[str],
-) -> Set[str]:
+) -> Dict[str, str]:
     """
-    Resolve canonical_ids to document_ids via ingestion_service graph API.
+    Resolve canonical_ids to a canonical_id → document_id map via the
+    ingestion_service graph API. The mapping (not just a set) lets the
+    caller apply the expansion ranking when capping fetched docs
+    (issue #30 Part 3).
     """
     if not canonical_ids:
-        return set()
+        return {}
 
     settings = get_settings()
     url = f"{settings.INGESTION_SERVICE_URL}/v1/graph/repos/{repo_id}/nodes"
@@ -102,21 +106,115 @@ async def canonical_ids_to_document_ids_http(
             resp.raise_for_status()
             data = resp.json()
 
-            document_ids = {node["document_id"] for node in data.get("nodes", [])}
+            mapping = {
+                node["canonical_id"]: node["document_id"]
+                for node in data.get("nodes", [])
+                if node.get("canonical_id") and node.get("document_id")
+            }
             logger.info(
                 f"Graph API: {len(canonical_ids)} canonical_ids → "
-                f"{len(document_ids)} document_ids"
+                f"{len(mapping)} document_ids"
             )
-            return document_ids
+            return mapping
 
         except Exception as e:
             logger.warning(f"Graph lookup failed: {e}")
-            return set()
+            return {}
 
 
 # ------------------------------------------------------------------
 # HYBRID RETRIEVAL (Vector → Canonical → Graph → Docs → Chunks)
 # ------------------------------------------------------------------
+
+def _rank_expanded_canonical_ids(
+    query: str,
+    repo_id: str,
+    seed_canonical_ids: Set[str],
+) -> List[str]:
+    """
+    Graph-expand from every seed and return expanded canonical_ids,
+    most seed-adjacent first, seeds excluded. The order drives the
+    MAX_EXPANDED_DOCS cap (issue #30 Part 3).
+    """
+    if not seed_canonical_ids:
+        return []
+
+    from rag_orchestrator.src.retrieval.codebase_utils import get_cached_graph
+
+    graph: CodebaseGraph = get_cached_graph(repo_id)
+    strategies = select_traversal_strategies(query, seed_canonical_ids)
+    # F-12: expand from every seed, not just the longest-named one
+    expanded_nodes: List[Node] = execute_traversals_from_seeds(
+        graph, seed_canonical_ids, strategies
+    )
+    return [
+        node.canonical_id
+        for node in expanded_nodes
+        if node.canonical_id not in seed_canonical_ids
+    ]
+
+
+async def _fetch_expanded_doc_chunks(
+    expanded_doc_ids: List[str],
+) -> List[tuple[str, List[Dict[str, Any]]]]:
+    """
+    Fetch chunks for the capped expanded docs concurrently (bounded by
+    MAX_CONCURRENT_DOC_FETCHES), k=EXPANDED_DOC_CHUNKS per doc. Results
+    come back in expanded_doc_ids order, so output stays deterministic.
+    """
+    settings = get_settings()
+    doc_url = f"{settings.VECTOR_STORE_URL}/v1/vectors/search-by-doc"
+    fetch_semaphore = asyncio.Semaphore(settings.MAX_CONCURRENT_DOC_FETCHES)
+
+    async with httpx.AsyncClient(timeout=200) as client:
+
+        async def fetch_one(doc_id: str) -> tuple[str, List[Dict[str, Any]]]:
+            async with fetch_semaphore:
+                try:
+                    resp = await client.post(
+                        doc_url,
+                        json={
+                            "document_id": doc_id,
+                            "k": settings.EXPANDED_DOC_CHUNKS,
+                        },
+                    )
+                    if resp.status_code == 200:
+                        return doc_id, resp.json().get("results", [])
+                    logger.warning(
+                        f"search-by-doc non-200 for {doc_id[:8]}: {resp.status_code}"
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed fetching expanded doc {doc_id[:8]}: {e}")
+                return doc_id, []
+
+        return list(
+            await asyncio.gather(*(fetch_one(doc_id) for doc_id in expanded_doc_ids))
+        )
+
+
+def _add_chunks(
+    doc_id: str,
+    results: List[Dict[str, Any]],
+    seen_chunk_ids: Set[str],
+    retrieved_chunks_by_document: Dict[str, List[RetrievedChunk]],
+) -> List[RetrievedChunk]:
+    """Append result rows as RetrievedChunks, skipping seen chunk_ids."""
+    added: List[RetrievedChunk] = []
+    for r in results:
+        if r["chunk_id"] in seen_chunk_ids:
+            continue
+        seen_chunk_ids.add(r["chunk_id"])
+        chunk = RetrievedChunk(
+            document_id=doc_id,
+            chunk_id=r["chunk_id"],
+            text=r["text"],
+            score=r.get("score"),
+            metadata=r.get("metadata", {}),
+        )
+        added.append(chunk)
+        retrieved_chunks_by_document.setdefault(doc_id, []).append(chunk)
+    return added
+
 
 async def hybrid_retrieve(
     query: str,
@@ -151,67 +249,53 @@ async def hybrid_retrieve(
         raw_results = resp.json().get("results", [])
 
     retrieved_chunks_by_document: Dict[str, List[RetrievedChunk]] = {}
+    seen_chunk_ids: Set[str] = set()
     seed_chunks: List[RetrievedChunk] = []
-
     for r in raw_results:
         doc_id = r.get("document_id") or r.get("metadata", {}).get("document_id")
         if not doc_id:
             continue
-        chunk = RetrievedChunk(
-            document_id=doc_id,
-            chunk_id=r["chunk_id"],
-            text=r["text"],
-            score=r.get("score"),
-            metadata=r.get("metadata", {}),
+        seed_chunks.extend(
+            _add_chunks(doc_id, [r], seen_chunk_ids, retrieved_chunks_by_document)
         )
-        seed_chunks.append(chunk)
-        retrieved_chunks_by_document.setdefault(doc_id, []).append(chunk)
 
     seed_canonical_ids = extract_canonical_ids_from_chunks(seed_chunks)
     logger.info(f"📊 {len(seed_chunks)} chunks → {len(seed_canonical_ids)} canonical_ids")
 
-    expanded_canonical_ids: Set[str] = set()
-    if seed_canonical_ids:
-        from rag_orchestrator.src.retrieval.codebase_utils import get_cached_graph
-
-        graph: CodebaseGraph = get_cached_graph(repo_id)
-        strategies = select_traversal_strategies(query, seed_canonical_ids)
-        # F-12: expand from every seed, not just the longest-named one
-        expanded_nodes: List[Node] = execute_traversals_from_seeds(
-            graph, seed_canonical_ids, strategies
-        )
-        expanded_canonical_ids = {node.canonical_id for node in expanded_nodes}
+    expanded_ranked = _rank_expanded_canonical_ids(query, repo_id, seed_canonical_ids)
+    expanded_canonical_ids = set(expanded_ranked)
 
     all_canonical_ids = seed_canonical_ids | expanded_canonical_ids
-    all_document_ids = await canonical_ids_to_document_ids_http(repo_id, all_canonical_ids)
+    canonical_to_doc = await canonical_to_document_map_http(repo_id, all_canonical_ids)
 
     seed_doc_ids = set(retrieved_chunks_by_document.keys())
-    missing_doc_ids = all_document_ids - seed_doc_ids
 
-    async with httpx.AsyncClient(timeout=200) as client:
-        for doc_id in missing_doc_ids:
-            try:
-                doc_url = f"{settings.VECTOR_STORE_URL}/v1/vectors/search-by-doc"
-                doc_payload = {"document_id": doc_id, "k": 10}
-                resp = await client.post(doc_url, json=doc_payload)
-                if resp.status_code == 200:
-                    for r in resp.json().get("results", []):
-                        chunk = RetrievedChunk(
-                            document_id=doc_id,
-                            chunk_id=r["chunk_id"],
-                            text=r["text"],
-                            score=r.get("score"),
-                            metadata=r.get("metadata", {}),
-                        )
-                        retrieved_chunks_by_document.setdefault(doc_id, []).append(chunk)
-            except Exception as e:
-                logger.warning(f"Failed fetching expanded doc {doc_id[:8]}: {e}")
+    # Issue #30 Part 3: cap expansion breadth. Rank order is preserved
+    # from execute_traversals_from_seeds; docs beyond MAX_EXPANDED_DOCS
+    # are counted as considered but never fetched.
+    expanded_doc_ids: List[str] = []
+    expanded_doc_seen: Set[str] = set(seed_doc_ids)
+    for cid in expanded_ranked:
+        doc_id = canonical_to_doc.get(cid)
+        if not doc_id or doc_id in expanded_doc_seen:
+            continue
+        expanded_doc_seen.add(doc_id)
+        expanded_doc_ids.append(doc_id)
+
+    expanded_docs_considered = len(expanded_doc_ids)
+    expanded_doc_ids = expanded_doc_ids[: settings.MAX_EXPANDED_DOCS]
+
+    fetched = await _fetch_expanded_doc_chunks(expanded_doc_ids)
+    for doc_id, doc_results in fetched:
+        _add_chunks(doc_id, doc_results, seen_chunk_ids, retrieved_chunks_by_document)
 
     retrieval_plan_dict = {
         "seed_canonical_ids": sorted(seed_canonical_ids),
         "expanded_canonical_ids": sorted(expanded_canonical_ids),
         "seed_docs": len(seed_doc_ids),
-        "expanded_docs": len(missing_doc_ids),
+        "expanded_docs_considered": expanded_docs_considered,
+        "expanded_docs_used": len(expanded_doc_ids),
+        "expanded_docs": len(expanded_doc_ids),
         "total_docs": len(retrieved_chunks_by_document),
     }
 
@@ -266,7 +350,10 @@ async def run_rag(
         retrieved_context,
         document_order=seed_document_ids,
         max_chunks_per_doc=max_chunks_per_doc,
-        max_total_chunks=9999,
+        # Issue #30 Part 3: real cap (was 9999). document_order lists
+        # seed docs before expanded ones, so truncation drops expansion
+        # first.
+        max_total_chunks=settings.MAX_TOTAL_CHUNKS,
         filter_chunk=chunk_filter_fn,
         debug=True,
     )

--- a/rag_orchestrator/src/core/simple_service.py
+++ b/rag_orchestrator/src/core/simple_service.py
@@ -24,7 +24,10 @@ from shared.embedders.query import embed_query
 from shared.embedders.factory import get_embedder
 from shared.retrieval.retrieval_plan import RetrievalPlan
 from rag_orchestrator.src.retrieval.execute_plan import execute_retrieval_plan
-from rag_orchestrator.src.retrieval.agent_adapter import prepare_chunks_for_agent
+from rag_orchestrator.src.retrieval.agent_adapter import (
+    build_sources,
+    prepare_chunks_for_agent,
+)
 from rag_orchestrator.src.retrieval.types import RetrievedChunk
 from rag_orchestrator.src.retrieval.traversal_planner import (
     expand_retrieval_plan,
@@ -265,6 +268,7 @@ async def run_simple_rag(  # noqa: C901 - decompose with WP-S8 retrieval work
 
     return SimpleRAGResult(
         answer=result.get("response", ""),
-        sources=list(dict.fromkeys(c["document_id"] for c in agent_chunks)),
-        # dict.fromkeys preserves order and deduplicates
+        # Issue #30 Part 4: uploaded-file chunks also carry canonical_id/
+        # relative_path metadata (pipeline.py), so labels beat raw UUIDs
+        sources=build_sources(agent_chunks),
     )

--- a/rag_orchestrator/src/retrieval/agent_adapter.py
+++ b/rag_orchestrator/src/retrieval/agent_adapter.py
@@ -9,6 +9,33 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)  # Can be overridden externally
 
 
+def build_sources(agent_chunks: List[Dict[str, object]]) -> List[str]:
+    """
+    Human-readable, deduplicated source labels (issue #30 Part 4).
+
+    Prefers canonical_id from chunk metadata (`path` or
+    `path#Class.method` per ADR-031), then relative_path, then the raw
+    document_id. Labels keep first-seen order, so with seeds ordered
+    before expanded documents the seed sources come first.
+    """
+    sources: List[str] = []
+    seen: set = set()
+    for c in agent_chunks:
+        raw_metadata = c.get("metadata")
+        metadata: Dict[str, object] = (
+            raw_metadata if isinstance(raw_metadata, dict) else {}
+        )
+        label = (
+            metadata.get("canonical_id")
+            or metadata.get("relative_path")
+            or c.get("document_id")
+        )
+        if label and label not in seen:
+            seen.add(label)
+            sources.append(str(label))
+    return sources
+
+
 def prepare_chunks_for_agent(
     retrieved: RetrievedContext,
     *,

--- a/rag_orchestrator/src/retrieval/traversal_selector.py
+++ b/rag_orchestrator/src/retrieval/traversal_selector.py
@@ -5,6 +5,7 @@ Keyword-driven traversal strategy selection.
 from typing import List, Callable, Set
 from functools import partial
 import logging
+import re
 
 from .codebase_queries import (
     traverse_defines,
@@ -16,6 +17,42 @@ from .codebase_queries import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Issue #30 Part 2: intent matching uses whole-word/phrase regexes, most
+# specific first. The old substring `if "in" in query` hijacked nearly
+# every query (ingest, print, main, find, …) into traverse_defines, so
+# caller queries never reached traverse_incoming_calls.
+
+_CALLER_PATTERNS = [
+    r"\bwho\s+calls\b",
+    r"\bwhat\s+calls\b",
+    r"\bcallers?\s+of\b",
+    r"\bcalled\s+by\b",
+    r"\bcallers\b",
+    r"\bwhat\s+(?:functions?|methods?|classes?)\s+calls?\b",
+    r"\bwhich\s+(?:functions?|methods?|classes?)\s+calls?\b",
+]
+
+_STRUCTURE_PATTERNS = [
+    r"\b(?:methods?|functions?|classes?)\s+(?:defined\s+)?in\b",
+    r"\b(?:methods?|functions?|classes?)\s+of\b",
+    r"\bdefined\s+in\b",
+]
+
+_CALLEE_PATTERNS = [
+    r"\bwhat\s+does\s+\S+\s+call\b",
+    r"\bcalls?\b",
+]
+
+_IMPORT_PATTERNS = [
+    r"\bimported\s+by\b",
+    r"\bimports?\b",
+]
+
+
+def _matches_any(query_lower: str, patterns: List[str]) -> bool:
+    return any(re.search(p, query_lower) for p in patterns)
+
 
 def select_traversal_strategies(
     query: str,
@@ -31,23 +68,24 @@ def select_traversal_strategies(
     query_lower = query.lower()
     strategies = []
 
-    # PRIORITY 1: "methods/functions/classes in X"
-    if any(term in query_lower for term in ["method", "methods", "function", "functions", "class", "classes", "in"]):
-        logger.debug("Selected: traverse_defines (methods/functions in X)")
-        strategies.append(partial(traverse_defines, depth=1))
-
-    # PRIORITY 2: "what calls X", "callers of X", "called by X"
-    elif any(term in query_lower for term in ["callers", "calls", "called by", "who calls"]):
+    # PRIORITY 1: caller intent — "who calls X", "callers of X",
+    # "what functions call X"
+    if _matches_any(query_lower, _CALLER_PATTERNS):
         logger.debug("Selected: traverse_incoming_calls (callers)")
         strategies.append(partial(traverse_incoming_calls, depth=1))
 
-    # PRIORITY 3: "what does X call"
-    elif any(term in query_lower for term in ["calls", "call"]):
+    # PRIORITY 2: structure intent — "methods in X", "defined in X"
+    elif _matches_any(query_lower, _STRUCTURE_PATTERNS):
+        logger.debug("Selected: traverse_defines (methods/functions in X)")
+        strategies.append(partial(traverse_defines, depth=1))
+
+    # PRIORITY 3: callee intent — "what does X call", "X calls Y"
+    elif _matches_any(query_lower, _CALLEE_PATTERNS):
         logger.debug("Selected: traverse_calls (outgoing calls)")
         strategies.append(partial(traverse_calls, depth=1))
 
-    # PRIORITY 4: "imports X"
-    elif "import" in query_lower:
+    # PRIORITY 4: import intent — "imports X", "imported by X"
+    elif _matches_any(query_lower, _IMPORT_PATTERNS):
         logger.debug("Selected: traverse_incoming_imports (imports)")
         strategies.append(partial(traverse_incoming_imports, depth=1))
 

--- a/rag_orchestrator/src/retrieval/traversal_selector.py
+++ b/rag_orchestrator/src/retrieval/traversal_selector.py
@@ -2,7 +2,7 @@
 """
 Keyword-driven traversal strategy selection.
 """
-from typing import List, Callable, Set
+from typing import Dict, List, Callable, Set
 from functools import partial
 import logging
 import re
@@ -137,13 +137,23 @@ def execute_traversals_from_seeds(
     bounded by vector-search top_k, so this stays cheap. Iteration is
     sorted for deterministic results; nodes are deduplicated across seeds.
     """
-    all_nodes: List[Node] = []
+    # Issue #30 Part 3: rank expanded nodes so downstream caps keep the
+    # most seed-adjacent ones. All strategies currently traverse at
+    # depth=1, so "reached from more seeds" is the adjacency signal;
+    # canonical_id breaks ties deterministically.
+    seed_hits: Dict[str, int] = {}
+    node_by_cid: Dict[str, Node] = {}
     for start_cid in sorted(seed_canonical_ids):
-        all_nodes.extend(execute_traversals(graph, start_cid, strategies))
+        for node in execute_traversals(graph, start_cid, strategies):
+            seed_hits[node.canonical_id] = seed_hits.get(node.canonical_id, 0) + 1
+            node_by_cid.setdefault(node.canonical_id, node)
 
-    unique_nodes = {node.canonical_id: node for node in all_nodes}.values()
+    ranked = sorted(
+        node_by_cid.values(),
+        key=lambda n: (-seed_hits[n.canonical_id], n.canonical_id),
+    )
     logger.info(
         f"Multi-seed expansion: {len(seed_canonical_ids)} seeds → "
-        f"{len(unique_nodes)} unique nodes"
+        f"{len(ranked)} unique nodes"
     )
-    return list(unique_nodes)
+    return ranked

--- a/rag_orchestrator/tests/conftest.py
+++ b/rag_orchestrator/tests/conftest.py
@@ -1,0 +1,11 @@
+# rag_orchestrator/tests/conftest.py
+# src.core.service imports via both `src.*` (service-local, covered by
+# pytest.ini pythonpath=.) and `rag_orchestrator.*`/`shared.*` (repo-root
+# packages, available in the Docker build context). Add the repo root so
+# unit tests can import the service layer outside Docker.
+import sys
+from pathlib import Path
+
+REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)

--- a/rag_orchestrator/tests/test_build_sources.py
+++ b/rag_orchestrator/tests/test_build_sources.py
@@ -1,0 +1,61 @@
+# rag_orchestrator/tests/test_build_sources.py
+"""
+Issue #30 Part 4: RAG sources are canonical IDs / paths, not a wall of
+duplicated document UUIDs.
+"""
+import pytest
+
+from src.retrieval.agent_adapter import build_sources
+
+pytestmark = pytest.mark.unit
+
+
+def chunk(document_id, canonical_id=None, relative_path=None):
+    metadata = {}
+    if canonical_id:
+        metadata["canonical_id"] = canonical_id
+    if relative_path:
+        metadata["relative_path"] = relative_path
+    return {"text": "x", "document_id": document_id, "chunk_id": "c", "metadata": metadata}
+
+
+def test_canonical_id_preferred_over_path_and_uuid():
+    chunks = [chunk("uuid-1", canonical_id="src/service.py#run_rag",
+                    relative_path="src/service.py")]
+    assert build_sources(chunks) == ["src/service.py#run_rag"]
+
+
+def test_relative_path_fallback_then_document_id():
+    chunks = [
+        chunk("uuid-1", relative_path="docs/readme.md"),
+        chunk("uuid-2"),
+    ]
+    assert build_sources(chunks) == ["docs/readme.md", "uuid-2"]
+
+
+def test_duplicates_collapse_preserving_first_seen_order():
+    chunks = [
+        chunk("uuid-1", canonical_id="a.py#f"),
+        chunk("uuid-1", canonical_id="a.py#f"),
+        chunk("uuid-2", canonical_id="b.py"),
+        chunk("uuid-1", canonical_id="a.py#f"),
+    ]
+    assert build_sources(chunks) == ["a.py#f", "b.py"]
+
+
+def test_seed_chunks_stay_ahead_of_expanded():
+    # prepare_chunks_for_agent emits seed docs before expanded docs;
+    # build_sources must not reorder them
+    chunks = [
+        chunk("seed-uuid", canonical_id="seed.py#hit"),
+        chunk("expanded-uuid", canonical_id="expanded.py#neighbor"),
+    ]
+    assert build_sources(chunks) == ["seed.py#hit", "expanded.py#neighbor"]
+
+
+def test_missing_metadata_dict_is_tolerated():
+    assert build_sources([{"document_id": "uuid-9", "metadata": None}]) == ["uuid-9"]
+
+
+def test_empty_input():
+    assert build_sources([]) == []

--- a/rag_orchestrator/tests/test_expansion_caps.py
+++ b/rag_orchestrator/tests/test_expansion_caps.py
@@ -1,0 +1,195 @@
+# rag_orchestrator/tests/test_expansion_caps.py
+"""
+Issue #30 Part 3: graph expansion is bounded, deduplicated, and observable.
+
+Before: every expanded document triggered a sequential search-by-doc HTTP
+call with k=10 and no cap on expanded docs, agent chunks were uncapped
+(max_total_chunks=9999), and nothing deduplicated chunk_ids across the
+seed/expanded merge.
+"""
+import asyncio
+import json
+from dataclasses import dataclass
+
+import httpx
+import pytest
+
+from rag_orchestrator.src.retrieval import codebase_utils
+from src.core.config import get_settings
+from src.core.service import hybrid_retrieve
+from src.retrieval.codebase_queries import CodebaseGraph, Node
+from src.retrieval.traversal_selector import execute_traversals_from_seeds
+
+pytestmark = pytest.mark.unit
+
+N_EXPANDED = 30  # more than MAX_EXPANDED_DOCS (default 20)
+
+
+def _build_graph() -> CodebaseGraph:
+    graph = CodebaseGraph()
+    graph.add_node(Node("a.py", "a.py"))
+    for i in range(N_EXPANDED):
+        cid = f"n{i:02d}"
+        graph.add_node(Node(cid, f"{cid}.py"))
+        graph.add_edge("a.py", cid, "DEFINES")
+    return graph
+
+
+class FakeBackend:
+    """Handles vector-store and graph-API requests, counting calls."""
+
+    def __init__(self):
+        self.search_calls = 0
+        self.search_by_doc_calls = 0
+        self.search_by_doc_docs = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/v1/vectors/search":
+            self.search_calls += 1
+            results = [
+                {
+                    "document_id": "seed-doc",
+                    "chunk_id": "seed-chunk-1",
+                    "text": "seed text",
+                    "score": 0.9,
+                    "metadata": {"canonical_id": "a.py", "repo_id": "repo-x"},
+                },
+                # duplicate chunk_id straight from the store — must collapse
+                {
+                    "document_id": "seed-doc",
+                    "chunk_id": "seed-chunk-1",
+                    "text": "seed text",
+                    "score": 0.9,
+                    "metadata": {"canonical_id": "a.py", "repo_id": "repo-x"},
+                },
+            ]
+            return httpx.Response(200, json={"results": results})
+
+        if path.startswith("/v1/graph/repos/"):
+            nodes = [{"canonical_id": "a.py", "document_id": "seed-doc"}]
+            nodes += [
+                {"canonical_id": f"n{i:02d}", "document_id": f"doc-{i:02d}"}
+                for i in range(N_EXPANDED)
+            ]
+            return httpx.Response(200, json={"nodes": nodes})
+
+        if path == "/v1/vectors/search-by-doc":
+            self.search_by_doc_calls += 1
+            doc_id = json.loads(request.content)["document_id"]
+            self.search_by_doc_docs.append(doc_id)
+            results = [
+                {
+                    "chunk_id": f"chunk-of-{doc_id}",
+                    "text": "expanded text",
+                    "score": 0.5,
+                    "metadata": {},
+                },
+                # same chunk_id returned by every doc — dedup must keep one
+                {
+                    "chunk_id": "dup-chunk",
+                    "text": "duplicated",
+                    "score": 0.4,
+                    "metadata": {},
+                },
+            ]
+            return httpx.Response(200, json={"results": results})
+
+        return httpx.Response(404)
+
+
+def _run_hybrid(monkeypatch, backend):
+    real_async_client = httpx.AsyncClient
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(backend)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+    monkeypatch.setattr(codebase_utils, "get_cached_graph", lambda repo_id: _build_graph())
+
+    return asyncio.run(
+        hybrid_retrieve(
+            query="explain the module",  # default routing → defines + calls
+            repo_id="repo-x",
+            query_embedding=[0.0] * 8,
+            top_k=5,
+        )
+    )
+
+
+def test_expansion_fetches_are_capped(monkeypatch):
+    backend = FakeBackend()
+    chunks_by_doc, plan = _run_hybrid(monkeypatch, backend)
+
+    cap = get_settings().MAX_EXPANDED_DOCS
+    assert backend.search_by_doc_calls == cap
+    # bounded number of vector-store calls: 1 seed search + capped fetches
+    assert backend.search_calls + backend.search_by_doc_calls == cap + 1
+
+    assert plan["expanded_docs_considered"] == N_EXPANDED
+    assert plan["expanded_docs_used"] == cap
+
+
+def test_no_duplicate_chunk_ids_across_seed_and_expansion(monkeypatch):
+    backend = FakeBackend()
+    chunks_by_doc, _ = _run_hybrid(monkeypatch, backend)
+
+    all_chunk_ids = [
+        c.chunk_id for chunks in chunks_by_doc.values() for c in chunks
+    ]
+    assert len(all_chunk_ids) == len(set(all_chunk_ids))
+    assert all_chunk_ids.count("dup-chunk") == 1
+    assert all_chunk_ids.count("seed-chunk-1") == 1
+
+
+def test_expanded_fetch_uses_configured_chunk_count(monkeypatch):
+    backend = FakeBackend()
+    captured_k = []
+
+    original_call = backend.__call__
+
+    def spying(request):
+        if request.url.path == "/v1/vectors/search-by-doc":
+            captured_k.append(json.loads(request.content)["k"])
+        return original_call(request)
+
+    _run_hybrid(monkeypatch, spying)
+
+    settings = get_settings()
+    assert captured_k and all(k == settings.EXPANDED_DOC_CHUNKS for k in captured_k)
+
+
+# ------------------------------------------------------------------
+# Ranking: nodes reached from more seeds come first
+# ------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class FakeNode:
+    canonical_id: str
+
+
+def test_expansion_ranks_by_seed_adjacency():
+    def strategy(graph, start_cid):
+        if start_cid == "seed1":
+            return [FakeNode("solo"), FakeNode("shared")]
+        return [FakeNode("shared")]
+
+    nodes = execute_traversals_from_seeds(
+        graph=None,
+        seed_canonical_ids={"seed1", "seed2"},
+        strategies=[strategy],
+    )
+    assert [n.canonical_id for n in nodes] == ["shared", "solo"]
+
+
+def test_ranking_ties_break_deterministically():
+    def strategy(graph, start_cid):
+        return [FakeNode("b"), FakeNode("a")]
+
+    nodes = execute_traversals_from_seeds(
+        graph=None,
+        seed_canonical_ids={"seed1"},
+        strategies=[strategy],
+    )
+    assert [n.canonical_id for n in nodes] == ["a", "b"]

--- a/rag_orchestrator/tests/test_repo_scoping.py
+++ b/rag_orchestrator/tests/test_repo_scoping.py
@@ -1,0 +1,132 @@
+# rag_orchestrator/tests/test_repo_scoping.py
+"""
+Issue #30 Part 1: the requested repo_id must survive the whole query path.
+
+Covers the three defects that made every UI query silently answer from the
+first completed repo:
+- the /v1/rag route dropped repo_id before calling run_rag()
+- the seed vector search had no repo_id metadata filter
+- the no-code-chunks fallback popped the entire metadata_filter, which
+  would reintroduce the cross-repo leak exactly when the requested repo
+  has no matching code chunks
+"""
+import asyncio
+import json
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import src.api.v1.routes as routes
+from src.api.v1.main import app
+from src.core.service import RAGResult, hybrid_retrieve
+
+pytestmark = pytest.mark.unit
+
+
+# ------------------------------------------------------------------
+# Route: repo_id forwarding
+# ------------------------------------------------------------------
+
+def test_route_forwards_repo_id(monkeypatch):
+    captured = {}
+
+    async def fake_run_rag(**kwargs):
+        captured.update(kwargs)
+        return RAGResult(
+            answer="ok", sources=[], repo_id=kwargs["repo_id"], retrieval_plan={}
+        )
+
+    monkeypatch.setattr(routes, "run_rag", fake_run_rag)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/rag", json={"query": "what does main do?", "repo_id": "repo-x"}
+    )
+
+    assert resp.status_code == 200
+    assert captured["repo_id"] == "repo-x"
+    assert resp.json()["repo_id"] == "repo-x"
+
+
+def test_route_forwards_none_when_repo_id_omitted(monkeypatch):
+    captured = {}
+
+    async def fake_run_rag(**kwargs):
+        captured.update(kwargs)
+        return RAGResult(
+            answer="ok", sources=[], repo_id="first-complete", retrieval_plan={}
+        )
+
+    monkeypatch.setattr(routes, "run_rag", fake_run_rag)
+
+    client = TestClient(app)
+    resp = client.post("/v1/rag", json={"query": "hello"})
+
+    assert resp.status_code == 200
+    assert captured["repo_id"] is None
+
+
+def test_route_propagates_unknown_repo_404(monkeypatch):
+    async def fake_run_rag(**kwargs):
+        raise HTTPException(404, "Repository not found")
+
+    monkeypatch.setattr(routes, "run_rag", fake_run_rag)
+
+    client = TestClient(app)
+    resp = client.post("/v1/rag", json={"query": "q", "repo_id": "nope"})
+
+    assert resp.status_code == 404
+
+
+# ------------------------------------------------------------------
+# hybrid_retrieve: seed filter and fallback stay repo-scoped
+# ------------------------------------------------------------------
+
+def _run_hybrid_with_empty_store(monkeypatch):
+    """Run hybrid_retrieve against a vector store that returns no results,
+    capturing every search payload it receives."""
+    search_payloads = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/vectors/search":
+            search_payloads.append(json.loads(request.content))
+        return httpx.Response(200, json={"results": []})
+
+    real_async_client = httpx.AsyncClient
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+    asyncio.run(
+        hybrid_retrieve(
+            query="anything",
+            repo_id="repo-x",
+            query_embedding=[0.0] * 8,
+            top_k=5,
+        )
+    )
+    return search_payloads
+
+
+def test_seed_search_is_repo_scoped(monkeypatch):
+    payloads = _run_hybrid_with_empty_store(monkeypatch)
+
+    assert payloads[0]["metadata_filter"] == {
+        "doc_type": "code",
+        "repo_id": "repo-x",
+    }
+
+
+def test_fallback_relaxes_doc_type_but_keeps_repo_scope(monkeypatch):
+    payloads = _run_hybrid_with_empty_store(monkeypatch)
+
+    # empty first response triggers the fallback retry
+    assert len(payloads) == 2
+    fallback_filter = payloads[1]["metadata_filter"]
+    assert fallback_filter == {"repo_id": "repo-x"}
+    assert "doc_type" not in fallback_filter

--- a/rag_orchestrator/tests/test_traversal_selector_routing.py
+++ b/rag_orchestrator/tests/test_traversal_selector_routing.py
@@ -1,0 +1,55 @@
+# rag_orchestrator/tests/test_traversal_selector_routing.py
+"""
+Issue #30 Part 2: traversal routing must match whole words/phrases.
+
+The old selector used substring matching with a bare "in" term, so any
+query containing ingest/print/main/find routed to traverse_defines and
+caller queries never reached traverse_incoming_calls.
+"""
+import pytest
+
+from src.retrieval.traversal_selector import select_traversal_strategies
+from src.retrieval.codebase_queries import (
+    traverse_calls,
+    traverse_defines,
+    traverse_incoming_calls,
+    traverse_incoming_imports,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def selected_funcs(query):
+    return [s.func for s in select_traversal_strategies(query, {"a.py#f"})]
+
+
+CASES = [
+    # caller intent — the Part 2 regression cases
+    ("what functions call ingest_repo?", [traverse_incoming_calls]),
+    ("who calls main?", [traverse_incoming_calls]),
+    ("callers of add", [traverse_incoming_calls]),
+    ("what calls build_pipeline", [traverse_incoming_calls]),
+    ("which methods call save?", [traverse_incoming_calls]),
+    ("functions called by run", [traverse_incoming_calls]),
+    # structure intent still works
+    ("methods in math_utils.py", [traverse_defines]),
+    ("what functions are defined in service.py", [traverse_defines]),
+    ("classes in the ingestion module", [traverse_defines]),
+    ("methods of RepoGraphBuilder", [traverse_defines]),
+    # callee intent
+    ("what does main call?", [traverse_calls]),
+    ("show the function calls made by run_rag", [traverse_calls]),
+    # import intent
+    ("what imports repo_naming", [traverse_incoming_imports]),
+    ("modules imported by service.py", [traverse_incoming_imports]),
+    # substring words no longer hijack routing → default (defines+calls)
+    ("explain ingest_repo", [traverse_defines, traverse_calls]),
+    ("how does print_summary work", [traverse_defines, traverse_calls]),
+    ("describe the main entrypoint", [traverse_defines, traverse_calls]),
+    ("find the string formatting logic", [traverse_defines, traverse_calls]),
+]
+
+
+@pytest.mark.parametrize("query,expected", CASES, ids=[c[0] for c in CASES])
+def test_query_routes_to_expected_strategies(query, expected):
+    assert selected_funcs(query) == expected


### PR DESCRIPTION
Implements all five parts of issue #30, in the order agreed there (1 → 5 → 2 → 4 → 3), one commit per part. Also carries the earlier unmerged post-audit-branch work (Phase 1 exit, CI slice, ANN index).

## Part 1 — requested repo_id honored end to end
- /v1/rag forwards `rag_query.repo_id` to `run_rag()` (was silently dropped, so every query answered from the first completed repo).
- Seed vector search filters on `repo_id` in addition to `doc_type`.
- The no-code-chunks fallback relaxes only `doc_type` and stays repo-scoped, instead of popping the whole metadata filter.
- Route re-raises HTTPException so unknown repo_id keeps its 404.

## Part 5 — real repository names
- `repo_naming.derive_repo_identity()` derives name/display_name from the git_url/local_path already persisted in `IngestionRequest.ingestion_metadata` (https, scp-style, ssh URLs; Windows/posix local paths). UUID labels remain only as fallback.
- `RepoSummary` gains `source_type`/`git_url`/`local_path`/`branch`; ingest-repo persists the derived identity going forward.

## Part 2 — caller queries reach traverse_incoming_calls
- `select_traversal_strategies()` matches whole words/phrases (most specific first) instead of substrings; the bare `"in"` term that hijacked nearly every query into `traverse_defines` is gone.

## Part 4 — readable sources
- `build_sources()`: canonical_id → relative_path → document_id, deduplicated, first-seen order (seeds first). Used by both graph RAG and simple RAG; response shape unchanged.

## Part 3 — bounded, deduplicated, parallel expansion
- `MAX_EXPANDED_DOCS` (20) cap over seed-adjacency-ranked expansion, `EXPANDED_DOC_CHUNKS` (3) per doc, `MAX_TOTAL_CHUNKS` (50) instead of 9999, concurrent fetches under a semaphore, chunk_id dedup across the merge, and `expanded_docs_considered`/`expanded_docs_used` in the retrieval plan.

## Tests
36 new unit tests across the five parts; all service suites green locally (ingestion 84, vector_store 7, llm 5, orchestrator 41). CI orchestrator step now collects tests via `--ignore=tests/__init__.py` (issue #24 workaround) so new files run automatically.

Live-stack verification against the multi-repo setup from the issue (repos `bc9acf95`/`d2fcf1f0`) is still worth doing before closing #30.