### PR TITLE
WP-G5: INHERITS and OVERRIDES edges

### DIFF
--- a/ingestion_service/src/core/codebase/repo_graph.py
+++ b/ingestion_service/src/core/codebase/repo_graph.py
@@ -42,6 +42,10 @@ class RepoGraph:
         # built by _resolve_imports. In-memory only; consumed by call
         # resolution (ADR-032 layer 2).
         self.import_bindings: Dict[str, dict] = {}
+        # WP-G5: class entity id -> resolved intra-repo base CLASS entity
+        # ids, in declaration order. Built by _resolve_inheritance;
+        # consumed by self/cls call resolution. In-memory only.
+        self.class_bases: Dict[str, List[str]] = {}
 
     def add_entity(self, relative_path: str, entity: dict):
         """

--- a/ingestion_service/src/core/codebase/repo_graph_builder.py
+++ b/ingestion_service/src/core/codebase/repo_graph_builder.py
@@ -1,5 +1,6 @@
 # ingestion_service/src/core/codebase/repo_graph_builder.py
 
+from collections import deque
 from pathlib import Path
 from typing import Optional, Tuple
 import ast
@@ -144,6 +145,7 @@ class RepoGraphBuilder:
         symbol_table = build_symbol_table(graph)
         self._attach_defines(graph)
         self._resolve_imports(graph)          # F-02 (WP-G2) — before calls
+        self._resolve_inheritance(graph, symbol_table)  # WP-G5 — before calls
         self._resolve_calls(graph, symbol_table)
         self._link_docs_to_code(graph, symbol_table)   # IS8 — last step
 
@@ -343,6 +345,172 @@ class RepoGraphBuilder:
         return canonical_id
 
     # -----------------------------
+    # WP-G5: INHERITS / OVERRIDES Relationships
+    # -----------------------------
+
+    def _resolve_inheritance(self, graph: RepoGraph, symbol_table) -> None:
+        """WP-G5: materialize the class hierarchy.
+
+        For each CLASS, resolve its `metadata.bases` strings through the
+        same machinery as call resolution (same-file → imports →
+        unique-global → EXTERNAL_SYMBOL) and emit
+        CLASS --INHERITS--> CLASS|EXTERNAL_SYMBOL edges. Then, for each
+        METHOD redefining a name that exists on the nearest resolved
+        ancestor, emit METHOD --OVERRIDES--> base METHOD. Also records
+        graph.class_bases so `self.x()` resolution can fall back to
+        inherited methods (ADR-032 step 1 extension)."""
+        classes = sorted(
+            (
+                e for e in graph.all_entities()
+                if e.get("artifact_type") == "CLASS"
+            ),
+            key=lambda e: e["canonical_id"],
+        )
+
+        # (from_cid, to_cid) -> {"bases": [strings], "confidence": float}
+        edges: dict = {}
+        for cls in classes:
+            rel = cls.get("relative_path", "")
+            for base_str in cls.get("metadata", {}).get("bases", []):
+                target_id, confidence = self._resolve_base(
+                    graph, symbol_table, rel, base_str
+                )
+                target = graph.get_entity_by_id(target_id)
+                if not target or target["id"] == cls["id"]:
+                    continue
+
+                if target.get("artifact_type") == "CLASS":
+                    bases = graph.class_bases.setdefault(cls["id"], [])
+                    if target["id"] not in bases:
+                        bases.append(target["id"])
+
+                key = (cls["canonical_id"], target["canonical_id"])
+                record = edges.setdefault(
+                    key, {"bases": [], "confidence": confidence}
+                )
+                record["bases"].append(base_str)
+                record["confidence"] = max(record["confidence"], confidence)
+
+        for (from_cid, to_cid) in sorted(edges):
+            record = edges[(from_cid, to_cid)]
+            graph.add_relationship({
+                "from_canonical_id": from_cid,
+                "to_canonical_id": to_cid,
+                "relation_type": "INHERITS",
+                "relationship_metadata": {
+                    "bases": record["bases"],
+                    "confidence": record["confidence"],
+                },
+            })
+
+        self._emit_overrides(graph, classes)
+
+    def _emit_overrides(self, graph: RepoGraph, classes: list) -> None:
+        """METHOD --OVERRIDES--> base METHOD for each method whose name is
+        defined on the nearest resolved intra-repo ancestor class."""
+        methods_by_class: dict = {}
+        for entity in graph.all_entities():
+            if entity.get("artifact_type") == "METHOD":
+                methods_by_class.setdefault(
+                    entity.get("parent_id"), []
+                ).append(entity)
+
+        for cls in classes:
+            if cls["id"] not in graph.class_bases:
+                continue
+            methods = sorted(
+                methods_by_class.get(cls["id"], []),
+                key=lambda m: m["canonical_id"],
+            )
+            for method in methods:
+                base_method_id = self._lookup_method_in_hierarchy(
+                    graph, cls["id"], method["name"], include_self=False
+                )
+                if not base_method_id:
+                    continue
+                base_method = graph.get_entity_by_id(base_method_id)
+                if not base_method:
+                    continue
+                graph.add_relationship({
+                    "from_canonical_id": method["canonical_id"],
+                    "to_canonical_id": base_method["canonical_id"],
+                    "relation_type": "OVERRIDES",
+                    "relationship_metadata": {
+                        "method_name": method["name"],
+                    },
+                })
+
+    def _resolve_base(
+        self, graph: RepoGraph, symbol_table, rel: str, base_str: str
+    ) -> Tuple[str, float]:
+        """Resolve one base-class expression to an entity id.
+
+        Subscripts are stripped (`Generic[T]` → `Generic`) so typed bases
+        resolve to the generic class. Order mirrors ADR-032: same-file →
+        import binding → unique-global → EXTERNAL_SYMBOL."""
+        name = base_str.split("[", 1)[0].strip()
+
+        if not _DOTTED_NAME.match(name):
+            # dynamic bases (call results, subscript-only) fold into an
+            # external symbol carrying the raw expression
+            return self._external_symbol_node(graph, name or base_str), 0.0
+
+        if "." in name:
+            receiver, attr = name.rsplit(".", 1)
+            binding = graph.import_bindings.get(rel, {}).get(receiver)
+            if binding:
+                return self._resolve_via_binding(
+                    graph, symbol_table, binding, attr
+                )
+            local_receiver = symbol_table.lookup_in_file(rel, receiver)
+            if local_receiver:
+                candidate = f"{local_receiver}.{attr}"
+                if graph.get_entity_by_id(candidate):
+                    return candidate, 1.0
+            return self._external_symbol_node(graph, name), 0.0
+
+        local = symbol_table.lookup_in_file(rel, name)
+        if local:
+            return local, 1.0
+
+        binding = graph.import_bindings.get(rel, {}).get(name)
+        if binding:
+            return self._resolve_via_binding(graph, symbol_table, binding, None)
+
+        candidates = symbol_table.lookup_global(name)
+        if len(candidates) == 1:
+            return candidates[0], 0.5
+
+        return self._external_symbol_node(graph, name), 0.0
+
+    def _lookup_method_in_hierarchy(
+        self,
+        graph: RepoGraph,
+        class_id: str,
+        method_name: str,
+        include_self: bool = True,
+    ) -> Optional[str]:
+        """Find `method_name` on class_id or its resolved intra-repo
+        ancestors (BFS in base-declaration order, cycle-guarded). Returns
+        the method entity id of the nearest definition, or None."""
+        initial = (
+            [class_id] if include_self
+            else list(graph.class_bases.get(class_id, []))
+        )
+        queue = deque(initial)
+        seen = {class_id, *initial}
+        while queue:
+            current = queue.popleft()
+            candidate = f"{current}.{method_name}"
+            if graph.get_entity_by_id(candidate):
+                return candidate
+            for base_id in graph.class_bases.get(current, []):
+                if base_id not in seen:
+                    seen.add(base_id)
+                    queue.append(base_id)
+        return None
+
+    # -----------------------------
     # CALL Relationships
     # -----------------------------
 
@@ -419,8 +587,12 @@ class RepoGraphBuilder:
         if receiver in ("self", "cls"):
             class_id = self._enclosing_class_id(site, graph)
             if class_id:
-                candidate = f"{class_id}.{name}"
-                if graph.get_entity_by_id(candidate):
+                # WP-G5: fall back through resolved base classes so a
+                # method defined only on the base still resolves.
+                candidate = self._lookup_method_in_hierarchy(
+                    graph, class_id, name
+                )
+                if candidate:
                     return candidate, 1.0
             return (
                 self._external_symbol_node(graph, f"{receiver}.{name}"),

--- a/ingestion_service/tests/codebase/test_inheritance_edges.py
+++ b/ingestion_service/tests/codebase/test_inheritance_edges.py
@@ -1,0 +1,160 @@
+# ingestion_service/tests/codebase/test_inheritance_edges.py
+"""
+WP-G5: CLASS --INHERITS--> CLASS and METHOD --OVERRIDES--> METHOD edges,
+plus self.x() falling back to base-class methods.
+"""
+import pytest
+from uuid import uuid4
+
+from src.core.codebase.repo_graph_builder import RepoGraphBuilder
+
+pytestmark = pytest.mark.unit
+
+
+def _write_repo(tmp_path):
+    (tmp_path / "base.py").write_text(
+        "class Animal:\n"
+        "    def speak(self):\n"
+        "        return 'generic'\n"
+        "    def eat(self):\n"
+        "        return 'eating'\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "dog.py").write_text(
+        "from base import Animal\n"
+        "\n"
+        "class Dog(Animal):\n"
+        "    def speak(self):\n"
+        "        return 'woof'\n"
+        "    def fetch(self):\n"
+        "        return self.eat()\n",  # eat() defined only on the base
+        encoding="utf-8",
+    )
+    (tmp_path / "models.py").write_text(
+        "from pydantic import BaseModel\n"
+        "\n"
+        "class Config(BaseModel):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "same_file.py").write_text(
+        "class Base:\n"
+        "    def run(self):\n"
+        "        return 0\n"
+        "\n"
+        "class Child(Base):\n"
+        "    def run(self):\n"
+        "        return 1\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def graph(tmp_path):
+    _write_repo(tmp_path)
+    return RepoGraphBuilder(tmp_path, ingestion_id=str(uuid4())).build()
+
+
+def _edges(graph, relation_type):
+    return {
+        (r["from_canonical_id"], r["to_canonical_id"])
+        for r in graph.relationships
+        if r["relation_type"] == relation_type
+    }
+
+
+def test_cross_file_inherits_edge_via_import(graph):
+    """class Dog(Animal) with Animal imported → INHERITS edge."""
+    assert ("dog.py#Dog", "base.py#Animal") in _edges(graph, "INHERITS")
+
+
+def test_same_file_inherits_edge(graph):
+    assert ("same_file.py#Child", "same_file.py#Base") in _edges(
+        graph, "INHERITS"
+    )
+
+
+def test_override_yields_overrides_edge(graph):
+    """Dog.speak overriding Animal.speak → OVERRIDES edge."""
+    assert ("dog.py#Dog.speak", "base.py#Animal.speak") in _edges(
+        graph, "OVERRIDES"
+    )
+    assert ("same_file.py#Child.run", "same_file.py#Base.run") in _edges(
+        graph, "OVERRIDES"
+    )
+
+
+def test_non_overriding_method_has_no_overrides_edge(graph):
+    overrides = _edges(graph, "OVERRIDES")
+    assert not any(f == "dog.py#Dog.fetch" for f, _ in overrides)
+
+
+def test_self_call_resolves_via_inheritance(graph):
+    """self.eat() inside Dog.fetch resolves to Animal.eat (defined only
+    on the base class)."""
+    call_edges = _edges(graph, "CALL")
+    assert ("dog.py#Dog.fetch", "base.py#Animal.eat") in call_edges
+
+
+def test_external_base_links_to_external_symbol(graph):
+    """class Config(BaseModel) with pydantic external → EXTERNAL_SYMBOL."""
+    inherits = _edges(graph, "INHERITS")
+    targets = {to for frm, to in inherits if frm == "models.py#Config"}
+    assert targets == {"EXTERNAL_SYMBOL:pydantic.BaseModel"}
+
+
+def test_inherits_metadata_carries_base_string_and_confidence(graph):
+    edge = next(
+        r for r in graph.relationships
+        if r["relation_type"] == "INHERITS"
+        and r["from_canonical_id"] == "dog.py#Dog"
+    )
+    assert edge["relationship_metadata"]["bases"] == ["Animal"]
+    assert edge["relationship_metadata"]["confidence"] == 1.0
+
+
+def test_rebuild_determinism(tmp_path):
+    _write_repo(tmp_path)
+    ingestion_id = str(uuid4())
+
+    def snapshot():
+        g = RepoGraphBuilder(tmp_path, ingestion_id=ingestion_id).build()
+        return [
+            (r["from_canonical_id"], r["to_canonical_id"], r["relation_type"])
+            for r in g.relationships
+            if r["relation_type"] in {"INHERITS", "OVERRIDES", "CALL"}
+        ]
+
+    assert snapshot() == snapshot()
+
+
+def test_subscripted_generic_base_resolves_to_class(tmp_path):
+    """class Stack(Container[int]) resolves the base to Container."""
+    (tmp_path / "gen.py").write_text(
+        "class Container:\n"
+        "    pass\n"
+        "\n"
+        "class Stack(Container[int]):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    graph = RepoGraphBuilder(tmp_path, ingestion_id=str(uuid4())).build()
+    assert ("gen.py#Stack", "gen.py#Container") in _edges(graph, "INHERITS")
+
+
+def test_inheritance_cycle_does_not_hang(tmp_path):
+    """Mutually-inheriting classes (illegal at runtime, parseable) must
+    not loop the hierarchy walk."""
+    (tmp_path / "cycle.py").write_text(
+        "class A(B):\n"
+        "    def go(self):\n"
+        "        return self.missing()\n"
+        "\n"
+        "class B(A):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    graph = RepoGraphBuilder(tmp_path, ingestion_id=str(uuid4())).build()
+    inherits = _edges(graph, "INHERITS")
+    assert ("cycle.py#A", "cycle.py#B") in inherits
+    assert ("cycle.py#B", "cycle.py#A") in inherits


### PR DESCRIPTION
Phase 2 Track A. Implements `DOCS/audit/02-Graph-Depth-Analysis.md` WP-G5: the class hierarchy becomes queryable and method overrides are explicit.

- New `_resolve_inheritance` pass (after imports, before calls): resolves each CLASS's `metadata.bases` via the same ADR-032 machinery as calls (same-file → import binding → unique-global → EXTERNAL_SYMBOL), emitting `CLASS --INHERITS--> CLASS` for intra-repo bases and `--> EXTERNAL_SYMBOL` for external ones. Subscripted bases (`Container[int]`) resolve to the generic class. Edge metadata: raw base strings + confidence.
- `METHOD --OVERRIDES--> base METHOD` for methods redefining a name found on the nearest resolved ancestor (BFS in declaration order, cycle-guarded).
- `self.x()`/`cls.x()` now falls back through resolved base classes — a method defined only on the base resolves at confidence 1.0 instead of becoming an EXTERNAL_SYMBOL edge.
- Hierarchy map (`graph.class_bases`) is in-memory only; the persisted model stays the ADR-030 two-table shape (`relation_type` strings).

Acceptance criteria from the WP, all covered by unit tests:
- cross-file `class B(A)` with `A` imported → INHERITS ✅
- `B.run` overriding `A.run` → OVERRIDES ✅
- `self.x()` defined only on the base resolves via inheritance ✅
- external bases (`BaseModel`) link to EXTERNAL_SYMBOL ✅
- plus rebuild determinism and inheritance-cycle safety

Ingestion unit suite: 94 passed (10 new).