### PR TITLE
WP-G6: traversal layer catches up with the deeper graph

### DIFF
--- a/rag_orchestrator/src/retrieval/codebase_queries.py
+++ b/rag_orchestrator/src/retrieval/codebase_queries.py
@@ -118,6 +118,28 @@ def traverse_incoming_imports(graph: CodebaseGraph, start_cid: str, depth: int =
     """
     return bfs_traversal(graph, start_cid, relation_types={"IMPORTS"}, direction="reverse", max_depth=depth)
 
+
+# WP-G6: traversals over the WP-G5 inheritance edges.
+
+def traverse_superclasses(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+    """Traverse INHERITS edges forward (what does this class inherit from?)."""
+    return bfs_traversal(graph, start_cid, relation_types={"INHERITS"}, direction="forward", max_depth=depth)
+
+
+def traverse_subclasses(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+    """Traverse INHERITS edges in reverse (what subclasses this class?)."""
+    return bfs_traversal(graph, start_cid, relation_types={"INHERITS"}, direction="reverse", max_depth=depth)
+
+
+def traverse_overrides(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+    """Traverse OVERRIDES edges forward (which base method does this override?)."""
+    return bfs_traversal(graph, start_cid, relation_types={"OVERRIDES"}, direction="forward", max_depth=depth)
+
+
+def traverse_overridden_by(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+    """Traverse OVERRIDES edges in reverse (which methods override this one?)."""
+    return bfs_traversal(graph, start_cid, relation_types={"OVERRIDES"}, direction="reverse", max_depth=depth)
+
 # --- API Calls ---
 
 def get_nodes_by_canonical_ids_from_api(repo_id: str, canonical_ids: List[str]) -> List[Dict]:

--- a/rag_orchestrator/src/retrieval/traversal_selector.py
+++ b/rag_orchestrator/src/retrieval/traversal_selector.py
@@ -12,6 +12,10 @@ from .codebase_queries import (
     traverse_calls,
     traverse_incoming_calls,
     traverse_incoming_imports,
+    traverse_superclasses,
+    traverse_subclasses,
+    traverse_overrides,
+    traverse_overridden_by,
     CodebaseGraph,
     Node
 )
@@ -22,31 +26,91 @@ logger = logging.getLogger(__name__)
 # specific first. The old substring `if "in" in query` hijacked nearly
 # every query (ingest, print, main, find, …) into traverse_defines, so
 # caller queries never reached traverse_incoming_calls.
+#
+# WP-G6: the if/elif chain is now an ordered rule table — data, not
+# code — so adding a strategy is one row. First matching row wins;
+# matching stays deterministic (no LLM router, per ADR-045).
 
-_CALLER_PATTERNS = [
-    r"\bwho\s+calls\b",
-    r"\bwhat\s+calls\b",
-    r"\bcallers?\s+of\b",
-    r"\bcalled\s+by\b",
-    r"\bcallers\b",
-    r"\bwhat\s+(?:functions?|methods?|classes?)\s+calls?\b",
-    r"\bwhich\s+(?:functions?|methods?|classes?)\s+calls?\b",
+def _s(traversal) -> Callable[[CodebaseGraph, str], List[Node]]:
+    return partial(traversal, depth=1)
+
+
+# (intent, patterns, strategy factories) — evaluated top to bottom.
+_RULE_TABLE: List[tuple] = [
+    (
+        "callers",
+        [
+            r"\bwho\s+calls\b",
+            r"\bwhat\s+calls\b",
+            r"\bcallers?\s+of\b",
+            r"\bcalled\s+by\b",
+            r"\bcallers\b",
+            r"\bwhat\s+(?:functions?|methods?|classes?)\s+calls?\b",
+            r"\bwhich\s+(?:functions?|methods?|classes?)\s+calls?\b",
+        ],
+        [lambda: _s(traverse_incoming_calls)],
+    ),
+    (
+        # WP-G6: "what subclasses Calculator", "which classes extend X"
+        "subclasses",
+        [
+            r"\bsubclass(?:es|ed)?\b",
+            r"\bextends\b",
+            r"\b(?:what|which|classes?)\s+extend\b",
+            r"\bwhat\s+inherits\s+from\b",
+            r"\bderived\s+(?:classes?\s+)?(?:of|from)\b",
+            r"\bchild(?:ren)?\s+class(?:es)?\b",
+        ],
+        [lambda: _s(traverse_subclasses)],
+    ),
+    (
+        # WP-G6: "base class of X", "what does X inherit from"
+        "superclasses",
+        [
+            r"\bsuperclass(?:es)?\b",
+            r"\bbase\s+class(?:es)?\b",
+            r"\bparent\s+class(?:es)?\b",
+            r"\binherits?\s+from\b",
+        ],
+        [lambda: _s(traverse_superclasses)],
+    ),
+    (
+        # WP-G6: overrides run both directions — "what overrides X" and
+        # "what does X override" share vocabulary too often to split.
+        "overrides",
+        [r"\boverrid(?:e|es|den|ing)\b"],
+        [lambda: _s(traverse_overrides), lambda: _s(traverse_overridden_by)],
+    ),
+    (
+        "structure",
+        [
+            r"\b(?:methods?|functions?|classes?)\s+(?:defined\s+)?in\b",
+            r"\b(?:methods?|functions?|classes?)\s+of\b",
+            r"\bdefined\s+in\b",
+        ],
+        [lambda: _s(traverse_defines)],
+    ),
+    (
+        "callees",
+        [
+            r"\bwhat\s+does\s+\S+\s+call\b",
+            r"\bcalls?\b",
+        ],
+        [lambda: _s(traverse_calls)],
+    ),
+    (
+        "imports",
+        [
+            r"\bimported\s+by\b",
+            r"\bimports?\b",
+        ],
+        [lambda: _s(traverse_incoming_imports)],
+    ),
 ]
 
-_STRUCTURE_PATTERNS = [
-    r"\b(?:methods?|functions?|classes?)\s+(?:defined\s+)?in\b",
-    r"\b(?:methods?|functions?|classes?)\s+of\b",
-    r"\bdefined\s+in\b",
-]
-
-_CALLEE_PATTERNS = [
-    r"\bwhat\s+does\s+\S+\s+call\b",
-    r"\bcalls?\b",
-]
-
-_IMPORT_PATTERNS = [
-    r"\bimported\s+by\b",
-    r"\bimports?\b",
+_DEFAULT_STRATEGIES = [
+    lambda: _s(traverse_defines),
+    lambda: _s(traverse_calls),
 ]
 
 
@@ -59,43 +123,23 @@ def select_traversal_strategies(
     seed_canonical_ids: Set[str]
 ) -> List[Callable[[CodebaseGraph, str], List[Node]]]:
     """
-    Select traversal strategies based on query intent.
+    Select traversal strategies based on query intent via the ordered
+    rule table; first matching row wins, else default (defines + calls).
 
     >>> strategies = select_traversal_strategies("methods in math_utils.py", ...)
     >>> len(strategies) > 0
     True
     """
     query_lower = query.lower()
-    strategies = []
 
-    # PRIORITY 1: caller intent — "who calls X", "callers of X",
-    # "what functions call X"
-    if _matches_any(query_lower, _CALLER_PATTERNS):
-        logger.debug("Selected: traverse_incoming_calls (callers)")
-        strategies.append(partial(traverse_incoming_calls, depth=1))
-
-    # PRIORITY 2: structure intent — "methods in X", "defined in X"
-    elif _matches_any(query_lower, _STRUCTURE_PATTERNS):
-        logger.debug("Selected: traverse_defines (methods/functions in X)")
-        strategies.append(partial(traverse_defines, depth=1))
-
-    # PRIORITY 3: callee intent — "what does X call", "X calls Y"
-    elif _matches_any(query_lower, _CALLEE_PATTERNS):
-        logger.debug("Selected: traverse_calls (outgoing calls)")
-        strategies.append(partial(traverse_calls, depth=1))
-
-    # PRIORITY 4: import intent — "imports X", "imported by X"
-    elif _matches_any(query_lower, _IMPORT_PATTERNS):
-        logger.debug("Selected: traverse_incoming_imports (imports)")
-        strategies.append(partial(traverse_incoming_imports, depth=1))
-
-    # DEFAULT: Comprehensive exploration
+    for intent, patterns, factories in _RULE_TABLE:
+        if _matches_any(query_lower, patterns):
+            logger.debug(f"Selected intent: {intent}")
+            strategies = [factory() for factory in factories]
+            break
     else:
         logger.debug("Selected: default (defines + calls)")
-        strategies.extend([
-            partial(traverse_defines, depth=1),
-            partial(traverse_calls, depth=1)
-        ])
+        strategies = [factory() for factory in _DEFAULT_STRATEGIES]
 
     logger.info(f"Selected {len(strategies)} traversal strategies for query: '{query[:50]}...'")
     return strategies

--- a/rag_orchestrator/tests/test_inheritance_traversal.py
+++ b/rag_orchestrator/tests/test_inheritance_traversal.py
@@ -1,0 +1,77 @@
+# rag_orchestrator/tests/test_inheritance_traversal.py
+"""
+WP-G6: the traversal layer exploits the WP-G5 INHERITS/OVERRIDES edges.
+"""
+import pytest
+
+from src.retrieval.codebase_queries import (
+    CodebaseGraph,
+    Node,
+    traverse_overridden_by,
+    traverse_overrides,
+    traverse_subclasses,
+    traverse_superclasses,
+)
+from src.retrieval.traversal_selector import (
+    execute_traversals_from_seeds,
+    select_traversal_strategies,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def graph():
+    """Calculator <- Scientific <- Graphing hierarchy, plus one override."""
+    g = CodebaseGraph()
+    for cid in [
+        "calc.py#Calculator",
+        "sci.py#Scientific",
+        "graph.py#Graphing",
+        "calc.py#Calculator.compute",
+        "sci.py#Scientific.compute",
+    ]:
+        g.add_node(Node(cid, cid.split("#")[0]))
+
+    g.add_edge("sci.py#Scientific", "calc.py#Calculator", "INHERITS")
+    g.add_edge("graph.py#Graphing", "sci.py#Scientific", "INHERITS")
+    g.add_edge(
+        "sci.py#Scientific.compute", "calc.py#Calculator.compute", "OVERRIDES"
+    )
+    return g
+
+
+def cids(nodes):
+    return {n.canonical_id for n in nodes}
+
+
+def test_traverse_subclasses_walks_reverse_inherits(graph):
+    assert cids(traverse_subclasses(graph, "calc.py#Calculator", depth=2)) == {
+        "sci.py#Scientific",
+        "graph.py#Graphing",
+    }
+
+
+def test_traverse_superclasses_walks_forward_inherits(graph):
+    assert cids(traverse_superclasses(graph, "graph.py#Graphing", depth=2)) == {
+        "sci.py#Scientific",
+        "calc.py#Calculator",
+    }
+
+
+def test_traverse_overrides_and_reverse(graph):
+    assert cids(
+        traverse_overrides(graph, "sci.py#Scientific.compute", depth=1)
+    ) == {"calc.py#Calculator.compute"}
+    assert cids(
+        traverse_overridden_by(graph, "calc.py#Calculator.compute", depth=1)
+    ) == {"sci.py#Scientific.compute"}
+
+
+def test_what_subclasses_calculator_end_to_end(graph):
+    """WP-G6 acceptance: 'what subclasses Calculator' returns subclass
+    nodes when expanded from the Calculator seed."""
+    seeds = {"calc.py#Calculator"}
+    strategies = select_traversal_strategies("what subclasses Calculator", seeds)
+    nodes = execute_traversals_from_seeds(graph, seeds, strategies)
+    assert "sci.py#Scientific" in cids(nodes)

--- a/rag_orchestrator/tests/test_traversal_selector_routing.py
+++ b/rag_orchestrator/tests/test_traversal_selector_routing.py
@@ -14,6 +14,10 @@ from src.retrieval.codebase_queries import (
     traverse_defines,
     traverse_incoming_calls,
     traverse_incoming_imports,
+    traverse_overridden_by,
+    traverse_overrides,
+    traverse_subclasses,
+    traverse_superclasses,
 )
 
 pytestmark = pytest.mark.unit
@@ -42,6 +46,17 @@ CASES = [
     # import intent
     ("what imports repo_naming", [traverse_incoming_imports]),
     ("modules imported by service.py", [traverse_incoming_imports]),
+    # WP-G6: inheritance intents
+    ("what subclasses Calculator", [traverse_subclasses]),
+    ("which classes extend BaseModel", [traverse_subclasses]),
+    ("what inherits from Animal", [traverse_subclasses]),
+    ("derived classes of Shape", [traverse_subclasses]),
+    ("what is the base class of Dog", [traverse_superclasses]),
+    ("what does Dog inherit from", [traverse_superclasses]),
+    ("superclasses of HttpVectorStore", [traverse_superclasses]),
+    # WP-G6: override intent runs both directions
+    ("what overrides speak", [traverse_overrides, traverse_overridden_by]),
+    ("which methods are overridden in Dog", [traverse_overrides, traverse_overridden_by]),
     # substring words no longer hijack routing → default (defines+calls)
     ("explain ingest_repo", [traverse_defines, traverse_calls]),
     ("how does print_summary work", [traverse_defines, traverse_calls]),


### PR DESCRIPTION
Phase 2 Track A, follows #33 (WP-G5). Implements `DOCS/audit/02-Graph-Depth-Analysis.md` WP-G6.

- New traversals over the WP-G5 edges: `traverse_superclasses`/`traverse_subclasses` (INHERITS forward/reverse), `traverse_overrides`/`traverse_overridden_by` (OVERRIDES forward/reverse).
- Selector refactored from an if/elif chain to an **ordered rule table** (data, not code) — adding a strategy is one row; first match wins; deterministic word-boundary regexes, no LLM router (ADR-045). Existing intents keep their exact behavior and priority.
- New intents: **subclasses** ("what subclasses Calculator", "which classes extend X", "what inherits from X"), **superclasses** ("base class of X", "what does X inherit from"), **overrides** (both directions).

WP acceptance criteria: "what subclasses Calculator" returns subclass nodes (end-to-end unit test over a built graph); all seeds expand (covered since F-12 by test_multi_seed_traversal); rule-table intent → strategy-list unit-test rows for every intent. Multi-seed + expansion caps landed earlier (issue #30 Part 3).

Orchestrator suite: 64 passed (13 new).