### PR TITLE
WP-M2: LLM resilience — fallbacks, retries, per-model timeouts

### DIFF
--- a/llm_service/src/api/v1/main.py
+++ b/llm_service/src/api/v1/main.py
@@ -9,7 +9,7 @@ from src.core.config import (
     DEFAULT_LLM_PROVIDER,
     OLLAMA_MODEL,
 )
-from src.core.llm_client import generate_completion
+from src.core.llm_client import AllProvidersFailedError, generate_completion
 from src.core.model_registry import UnknownModelAliasError
 
 app = FastAPI(title="LLM Service")
@@ -38,6 +38,13 @@ async def generate(
         )
     except ValueError as e:
         return JSONResponse(status_code=400, content={"error": str(e)})
+    except AllProvidersFailedError as e:
+        # WP-M2: actionable outage message, not a stack trace
+        logging.error("All LLM providers failed: %s", e)
+        return JSONResponse(
+            status_code=503,
+            content={"error": str(e), "attempted_models": e.attempted},
+        )
     except Exception as e:
         logging.exception("Error in /generate")
         return JSONResponse(status_code=500, content={"error": str(e)})

--- a/llm_service/src/core/llm_client.py
+++ b/llm_service/src/core/llm_client.py
@@ -3,6 +3,9 @@
 # provider/model params; Ollama remains the default; llm_service stays
 # the seam owning prompts and model policy — other services never call
 # vendors directly.
+# WP-M2: provider outages degrade gracefully — per-attempt LiteLLM
+# retries with backoff, then the registry's fallback chain; only when
+# every candidate fails does the request error (503 at the API layer).
 import logging
 
 import litellm
@@ -12,6 +15,24 @@ from src.core.prompts import PROMPT_TEMPLATE_VERSION, build_messages
 
 logger = logging.getLogger(__name__)
 
+# WP-M2: retries within one candidate model before falling back.
+# LiteLLM applies exponential backoff between attempts.
+NUM_RETRIES = 2
+
+
+class AllProvidersFailedError(RuntimeError):
+    """Every model in the fallback chain failed (WP-M2 → 503)."""
+
+    def __init__(self, attempted: list[str], last_error: Exception):
+        self.attempted = attempted
+        self.last_error = last_error
+        super().__init__(
+            "All configured LLM providers failed. "
+            f"Tried, in order: {', '.join(attempted)}. "
+            f"Last error: {last_error}. "
+            "Check provider availability, API keys, and models.yaml."
+        )
+
 
 async def generate_completion(
     *,
@@ -20,8 +41,37 @@ async def generate_completion(
     provider: str | None = None,
     model: str | None = None,
 ) -> dict:
-    resolved = get_registry().resolve(provider, model)
-    return await _complete(resolved, context=context, query=query)
+    registry = get_registry()
+    primary = registry.resolve(provider, model)
+    chain = registry.fallback_chain(primary)
+
+    last_error: Exception | None = None
+    for position, candidate in enumerate(chain):
+        try:
+            result = await _complete(candidate, context=context, query=query)
+        except Exception as e:  # noqa: BLE001 - any provider error → next
+            last_error = e
+            logger.warning(
+                "LLM candidate failed, %s remaining",
+                len(chain) - position - 1,
+                extra={"failed_model": candidate.model, "error": str(e)},
+            )
+            continue
+
+        if position > 0:
+            # structured circuit-note: a fallback fired
+            logger.warning(
+                "LLM fallback fired",
+                extra={
+                    "fallback_from": primary.model,
+                    "fallback_to": candidate.model,
+                },
+            )
+            result["fallback_from"] = primary.model
+        return result
+
+    assert last_error is not None
+    raise AllProvidersFailedError([c.model for c in chain], last_error)
 
 
 async def _complete(
@@ -31,6 +81,7 @@ async def _complete(
         "model": resolved.model,
         "messages": build_messages(context, query),
         "timeout": resolved.timeout,
+        "num_retries": NUM_RETRIES,
     }
     if resolved.api_base:
         kwargs["api_base"] = resolved.api_base

--- a/llm_service/src/core/model_registry.py
+++ b/llm_service/src/core/model_registry.py
@@ -90,6 +90,25 @@ class ModelRegistry:
             for alias in self.aliases()
         ]
 
+    def fallback_chain(self, primary: ResolvedModel) -> List[ResolvedModel]:
+        """WP-M2: the ordered attempt chain for a resolved model —
+        the primary first, then its configured fallback aliases.
+        Unknown fallback aliases are skipped; duplicates collapse.
+        Non-alias resolutions (raw strings, legacy pairs) have no
+        fallbacks."""
+        chain = [primary]
+        seen = {primary.model}
+        if primary.alias:
+            for fallback_alias in self.fallbacks.get(primary.alias, []):
+                if fallback_alias not in self._aliases:
+                    continue
+                candidate = self._from_alias(fallback_alias)
+                if candidate.model in seen:
+                    continue
+                seen.add(candidate.model)
+                chain.append(candidate)
+        return chain
+
     def resolve(
         self, provider: Optional[str], model: Optional[str]
     ) -> ResolvedModel:

--- a/llm_service/tests/core/test_llm_resilience.py
+++ b/llm_service/tests/core/test_llm_resilience.py
@@ -1,0 +1,160 @@
+# llm_service/tests/core/test_llm_resilience.py
+"""
+WP-M2: fallbacks, retries, timeouts — outages degrade gracefully.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+import src.core.llm_client as llm_client
+from src.api.v1.main import app
+from src.core.llm_client import AllProvidersFailedError
+from src.core.model_registry import ModelRegistry
+
+CONFIG = {
+    "models": {
+        "primary": "anthropic/claude-sonnet-5",
+        "backup": "openai/gpt-5.1",
+        "slow": {"model": "ollama/llama3:70b", "timeout": 300},
+    },
+    "fallbacks": {
+        "primary": ["backup", "missing-alias", "slow"],
+    },
+    "timeouts": {"default": 120},
+}
+
+
+class _FakeMessage:
+    content = "answer"
+
+
+class _FakeChoice:
+    message = _FakeMessage()
+
+
+class _FakeResponse:
+    choices = [_FakeChoice()]
+    usage = None
+
+
+@pytest.fixture()
+def registry(monkeypatch):
+    reg = ModelRegistry(CONFIG)
+    monkeypatch.setattr(llm_client, "get_registry", lambda: reg)
+    return reg
+
+
+def test_fallback_chain_order_skips_unknown_and_dedupes(registry):
+    primary = registry.resolve(None, "primary")
+    chain = registry.fallback_chain(primary)
+    assert [c.model for c in chain] == [
+        "anthropic/claude-sonnet-5",
+        "openai/gpt-5.1",
+        "ollama/llama3:70b",
+    ]
+
+
+def test_raw_model_has_no_fallbacks(registry):
+    primary = registry.resolve(None, "mistral/mistral-large")
+    assert [c.model for c in registry.fallback_chain(primary)] == [
+        "mistral/mistral-large"
+    ]
+
+
+async def test_primary_failure_answers_from_fallback(registry, monkeypatch):
+    attempted = []
+
+    async def flaky_acompletion(**kwargs):
+        attempted.append(kwargs["model"])
+        if kwargs["model"] == "anthropic/claude-sonnet-5":
+            raise RuntimeError("provider down")
+        return _FakeResponse()
+
+    monkeypatch.setattr(llm_client.litellm, "acompletion", flaky_acompletion)
+
+    result = await llm_client.generate_completion(
+        context="c", query="q", model="primary"
+    )
+
+    assert attempted == ["anthropic/claude-sonnet-5", "openai/gpt-5.1"]
+    # the response names the model actually used, and where it fell from
+    assert result["model"] == "openai/gpt-5.1"
+    assert result["fallback_from"] == "anthropic/claude-sonnet-5"
+    assert result["response"] == "answer"
+
+
+async def test_no_fallback_marker_on_primary_success(registry, monkeypatch):
+    async def ok_acompletion(**kwargs):
+        return _FakeResponse()
+
+    monkeypatch.setattr(llm_client.litellm, "acompletion", ok_acompletion)
+
+    result = await llm_client.generate_completion(
+        context="c", query="q", model="primary"
+    )
+    assert "fallback_from" not in result
+
+
+async def test_all_providers_down_raises_actionable_error(
+    registry, monkeypatch
+):
+    async def dead_acompletion(**kwargs):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(llm_client.litellm, "acompletion", dead_acompletion)
+
+    with pytest.raises(AllProvidersFailedError) as exc_info:
+        await llm_client.generate_completion(
+            context="c", query="q", model="primary"
+        )
+
+    err = exc_info.value
+    assert err.attempted == [
+        "anthropic/claude-sonnet-5",
+        "openai/gpt-5.1",
+        "ollama/llama3:70b",
+    ]
+    assert "connection refused" in str(err)
+
+
+async def test_per_model_timeout_and_retries_passed(registry, monkeypatch):
+    captured = []
+
+    async def failing_then_ok(**kwargs):
+        captured.append((kwargs["model"], kwargs["timeout"], kwargs["num_retries"]))
+        if len(captured) < 3:
+            raise RuntimeError("down")
+        return _FakeResponse()
+
+    monkeypatch.setattr(llm_client.litellm, "acompletion", failing_then_ok)
+
+    await llm_client.generate_completion(context="c", query="q", model="primary")
+
+    # each candidate carries its own timeout; retries delegated to LiteLLM
+    assert captured == [
+        ("anthropic/claude-sonnet-5", 120.0, llm_client.NUM_RETRIES),
+        ("openai/gpt-5.1", 120.0, llm_client.NUM_RETRIES),
+        ("ollama/llama3:70b", 300.0, llm_client.NUM_RETRIES),
+    ]
+
+
+def test_endpoint_returns_503_when_all_providers_fail(monkeypatch):
+    async def fake_generate(**kwargs):
+        raise AllProvidersFailedError(
+            ["anthropic/claude-sonnet-5", "openai/gpt-5.1"],
+            RuntimeError("connection refused"),
+        )
+
+    monkeypatch.setattr(
+        "src.api.v1.main.generate_completion", fake_generate
+    )
+
+    client = TestClient(app)
+    response = client.post("/generate", json={"query": "q"})
+
+    assert response.status_code == 503
+    body = response.json()
+    assert "All configured LLM providers failed" in body["error"]
+    assert body["attempted_models"] == [
+        "anthropic/claude-sonnet-5",
+        "openai/gpt-5.1",
+    ]


### PR DESCRIPTION
Phase 2 Track B, follows #35 (WP-M1).

- `generate_completion` walks the registry's **fallback chain**: primary alias, then its `models.yaml` fallbacks (unknown aliases skipped, dupes collapsed; raw strings/legacy pairs get no fallbacks). Each candidate passes `num_retries=2` to LiteLLM (exponential backoff inside a candidate).
- Fallback firing is circuit-noted in structured logs (`fallback_from`/`fallback_to`) and the response carries `fallback_from` + the actually-used `model` for UI display.
- All candidates down → **503** with the ordered attempt list and an actionable message (availability / API keys / models.yaml), never a stack trace.
- Per-model timeout travels with each candidate (WP-M1 precedence).

**Deviation, called out:** `litellm.Router` was not adopted — the registry is already the single source of aliases/fallbacks and a Router deployment list would duplicate it; the explicit chain is deterministic and unit-testable. Router semantics return with Option B (LiteLLM Proxy) when multi-tenancy needs budgets/virtual keys.

Acceptance criteria: primary mocked to fail → answer from fallback naming the fallback model ✅ · all providers down → 503 actionable ✅ · per-model timeout respected (mock-asserted per candidate) ✅.

llm_service: 26 passed (7 new).