### PR TITLE
WP-M5: model picker in the product surface

### DIFF
--- a/ingestion_service/src/ui/gradio_app.py
+++ b/ingestion_service/src/ui/gradio_app.py
@@ -154,6 +154,37 @@ def refresh_repos():
         #return gr.update(choices=[], value=None)
         return gr.Dropdown(choices=[], value=None)
 
+def refresh_models():
+    """WP-M5: fetch the model-alias menu via the orchestrator passthrough."""
+    try:
+        response = requests.get(f"{RAG_API_BASE_URL}/v1/models", timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        choices = [
+            (f"{m['alias']} — {m['model']}", m["alias"])
+            for m in data.get("models", [])
+        ]
+        return gr.Dropdown(
+            choices=choices,
+            value=data.get("default"),
+            allow_custom_value=True,
+        )
+    except Exception as exc:
+        print(f"Failed to fetch model menu: {exc}")
+        return gr.Dropdown(choices=[], value=None, allow_custom_value=True)
+
+
+def _model_line(data: dict) -> str:
+    """WP-M5: show which model actually answered (incl. fallbacks)."""
+    model_used = data.get("model_used")
+    if not model_used:
+        return ""
+    line = f"\n**Model:** {model_used}"
+    if data.get("fallback_from"):
+        line += f" *(fell back from {data['fallback_from']})*"
+    return line
+
+
 def submit_rag_query(query: str, repo_id: str | None, top_k: int, provider: str | None, model: str | None):
     """Submit RAG query with repo_id."""
     try:
@@ -186,7 +217,7 @@ def submit_rag_query(query: str, repo_id: str | None, top_k: int, provider: str 
         sources = data.get("sources", [])
         formatted_sources = "\n".join(f"• {s}" for s in sources)
 
-        return f"""🎯 **Repository:** {repo_id[:8]}...
+        return f"""🎯 **Repository:** {repo_id[:8]}...{_model_line(data)}
 
 **Answer:**
 {answer}
@@ -225,7 +256,11 @@ def submit_simple_rag_query(query: str, top_k: int, provider: str | None, model:
         answer = data.get("answer", "")
         sources = data.get("sources", [])
         formatted_sources = "\n".join(f"• {s}" for s in sources)
-        return f"**Answer:**\n{answer}\n\n**Sources:**\n{formatted_sources or 'None found.'}"
+        return (
+            f"**Answer:**\n{answer}\n\n"
+            f"**Sources:**\n{formatted_sources or 'None found.'}"
+            f"{_model_line(data)}"
+        )
 
     except Exception as exc:
         return f"❌ Error: {exc}"
@@ -348,9 +383,12 @@ def build_ui():
                 placeholder="ollama",
                 scale=2
             )
-            model = gr.Textbox(  # type: ignore
+            model = gr.Dropdown(  # type: ignore
                 label="🧠 Model",
-                placeholder="Qwen3:1.7b",
+                choices=[],
+                value=None,
+                allow_custom_value=True,
+                info="Alias from llm_service, or a raw provider/model string",
                 scale=2
             )
 
@@ -374,7 +412,13 @@ def build_ui():
         with gr.Row():
             doc_top_k = gr.Number(label="📊 Top K", value=5, precision=0, minimum=1, maximum=50)
             doc_provider = gr.Textbox(label="🤖 LLM Provider", placeholder="ollama")
-            doc_model = gr.Textbox(label="🧠 Model", placeholder="Qwen3:1.7b")
+            doc_model = gr.Dropdown(
+                label="🧠 Model",
+                choices=[],
+                value=None,
+                allow_custom_value=True,
+                info="Alias from llm_service, or a raw provider/model string",
+            )
 
         doc_btn = gr.Button("🔍 Ask Document RAG", variant="secondary", size="lg")
         doc_output = gr.Textbox(label="📄 Response", lines=15, max_lines=20)
@@ -399,8 +443,10 @@ def build_ui():
             outputs=rag_output,
         )
 
-        # Auto-refresh repos when UI loads
+        # Auto-refresh repos and the model menu when UI loads
         demo.load(refresh_repos, outputs=repo_dropdown)
+        demo.load(refresh_models, outputs=model)
+        demo.load(refresh_models, outputs=doc_model)
 
     return demo
 

--- a/llm_service/src/api/v1/main.py
+++ b/llm_service/src/api/v1/main.py
@@ -10,7 +10,11 @@ from src.core.config import (
     OLLAMA_MODEL,
 )
 from src.core.llm_client import AllProvidersFailedError, generate_completion
-from src.core.model_registry import UnknownModelAliasError
+from src.core.model_registry import (
+    DEFAULT_ALIAS,
+    UnknownModelAliasError,
+    get_registry,
+)
 
 app = FastAPI(title="LLM Service")
 
@@ -48,6 +52,12 @@ async def generate(
     except Exception as e:
         logging.exception("Error in /generate")
         return JSONResponse(status_code=500, content={"error": str(e)})
+
+@app.get("/v1/models")
+def list_models() -> dict:
+    """WP-M5: the model menu — aliases from models.yaml + the default."""
+    return {"models": get_registry().describe(), "default": DEFAULT_ALIAS}
+
 
 @app.get("/health")
 def health_check() -> dict:

--- a/llm_service/src/api/v1/summarize.py
+++ b/llm_service/src/api/v1/summarize.py
@@ -3,11 +3,8 @@ import logging
 from uuid import UUID
 from typing import List
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
-from src.core.config import (
-    DEFAULT_LLM_PROVIDER,
-)
 from src.core.llm_client import generate_completion
 
 router = APIRouter(prefix="/v1/summarize", tags=["summaries"])
@@ -60,8 +57,15 @@ async def update_document_summary(ingestion_id: str, summary: str):
 
 
 @router.post("/{ingestion_id}")
-async def generate_summary(ingestion_id: str):
-    """MS7-IS2: Generate LLM summary for document ingestion."""
+async def generate_summary(
+    ingestion_id: str,
+    provider: str | None = Query(None),
+    model: str | None = Query(None),
+):
+    """MS7-IS2: Generate LLM summary for document ingestion.
+
+    WP-M5: honors the model alias/provider params like /generate does;
+    omitted → the registry's default model (previously hardcoded)."""
     try:
         logger.info(f"summarize.py generate_summary: {ingestion_id}")
         UUID(ingestion_id)  # validate format
@@ -87,8 +91,8 @@ async def generate_summary(ingestion_id: str):
         result = await generate_completion(
             context=context,
             query=query,
-            provider=DEFAULT_LLM_PROVIDER,
-            model="phi4-mini:latest",
+            provider=provider,
+            model=model,
         )
 
         summary = result.get("response", "Summary generation failed")

--- a/llm_service/tests/api/test_models_endpoint.py
+++ b/llm_service/tests/api/test_models_endpoint.py
@@ -1,0 +1,56 @@
+# llm_service/tests/api/test_models_endpoint.py
+"""
+WP-M5: GET /v1/models lists aliases and marks the default.
+"""
+from fastapi.testclient import TestClient
+
+from src.api.v1.main import app
+
+client = TestClient(app)
+
+
+def test_models_endpoint_lists_aliases_with_default():
+    response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["default"] == "default"
+
+    by_alias = {m["alias"]: m for m in body["models"]}
+    assert by_alias["default"]["is_default"] is True
+    # aliases shipped in llm_service/models.yaml
+    assert "smart" in by_alias
+    assert by_alias["smart"]["model"] == "anthropic/claude-sonnet-5"
+    assert by_alias["smart"]["is_default"] is False
+
+
+def test_summarize_forwards_model_alias(monkeypatch):
+    """WP-M5: /v1/summarize honors the model param instead of the old
+    hardcoded phi4-mini."""
+    captured = {}
+
+    async def fake_fetch_chunks(ingestion_id):
+        return ["chunk text"]
+
+    async def fake_update(ingestion_id, summary):
+        return None
+
+    async def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {"response": "a summary"}
+
+    monkeypatch.setattr("src.api.v1.summarize.fetch_chunks", fake_fetch_chunks)
+    monkeypatch.setattr(
+        "src.api.v1.summarize.update_document_summary", fake_update
+    )
+    monkeypatch.setattr(
+        "src.api.v1.summarize.generate_completion", fake_generate
+    )
+
+    response = client.post(
+        "/v1/summarize/123e4567-e89b-12d3-a456-426614174000?model=smart"
+    )
+
+    assert response.status_code == 200
+    assert captured["model"] == "smart"
+    assert response.json()["summary"] == "a summary"

--- a/rag_orchestrator/src/api/v1/models.py
+++ b/rag_orchestrator/src/api/v1/models.py
@@ -15,6 +15,10 @@ class RAGResponse(BaseModel):  # Updated name
     sources: List[str]
     repo_id: str  # NEW
     retrieval_plan: Dict[str, Any]  # NEW: Graph expansion details
+    # WP-M5: which model actually answered (incl. WP-M2 fallbacks)
+    model_used: Optional[str] = None
+    model_alias: Optional[str] = None
+    fallback_from: Optional[str] = None
 
 class SearchQuery(BaseModel):
     question: str
@@ -30,3 +34,7 @@ class SimpleRAGQuery(BaseModel):
 class SimpleRAGResponse(BaseModel):  # Updated name
     answer: str
     sources: List[str]
+    # WP-M5: which model actually answered (incl. WP-M2 fallbacks)
+    model_used: Optional[str] = None
+    model_alias: Optional[str] = None
+    fallback_from: Optional[str] = None

--- a/rag_orchestrator/src/api/v1/routes.py
+++ b/rag_orchestrator/src/api/v1/routes.py
@@ -2,7 +2,10 @@
 
 import logging
 
+import httpx
+
 from src.api.v1.models import RAGQuery, RAGResponse, SimpleRAGQuery,SimpleRAGResponse
+from src.core.config import get_settings
 from src.core.service import run_rag#, search_documents
 from fastapi import APIRouter, HTTPException
 from src.core.simple_service import run_simple_rag  # new - no graph
@@ -54,6 +57,21 @@ async def rag_endpoint(rag_query: RAGQuery):
             status_code=500,
             detail="An error occurred while processing the RAG request.",
         )
+
+
+@router.get("/models")
+async def list_models():
+    """WP-M5: pass through the llm_service model menu so the UI can
+    build its dropdown without reaching llm_service directly."""
+    settings = get_settings()
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(f"{settings.LLM_SERVICE_URL}/v1/models")
+            resp.raise_for_status()
+            return resp.json()
+    except Exception as e:
+        logger.error(f"Failed to fetch model menu: {e}")
+        raise HTTPException(502, "llm_service model menu unavailable")
 
 
 @router.post("/rag/simple", response_model=SimpleRAGResponse)

--- a/rag_orchestrator/src/core/service.py
+++ b/rag_orchestrator/src/core/service.py
@@ -41,6 +41,10 @@ class RAGResult(BaseModel):
     sources: List[str]
     repo_id: str
     retrieval_plan: Dict[str, Any]
+    # WP-M5: model actually used by llm_service (incl. WP-M2 fallbacks)
+    model_used: Optional[str] = None
+    model_alias: Optional[str] = None
+    fallback_from: Optional[str] = None
 
 
 # ------------------------------------------------------------------
@@ -393,4 +397,7 @@ async def run_rag(
         sources=sources,
         repo_id=resolved_repo_id,
         retrieval_plan=retrieval_plan_dict,
+        model_used=result.get("model"),
+        model_alias=result.get("model_alias"),
+        fallback_from=result.get("fallback_from"),
     )

--- a/rag_orchestrator/src/core/simple_service.py
+++ b/rag_orchestrator/src/core/simple_service.py
@@ -40,6 +40,10 @@ logger = logging.getLogger(__name__)
 class SimpleRAGResult(BaseModel):
     answer: str
     sources: List[str]
+    # WP-M5: model actually used by llm_service (incl. WP-M2 fallbacks)
+    model_used: Optional[str] = None
+    model_alias: Optional[str] = None
+    fallback_from: Optional[str] = None
 
 
 async def run_simple_rag(  # noqa: C901 - decompose with WP-S8 retrieval work
@@ -271,4 +275,7 @@ async def run_simple_rag(  # noqa: C901 - decompose with WP-S8 retrieval work
         # Issue #30 Part 4: uploaded-file chunks also carry canonical_id/
         # relative_path metadata (pipeline.py), so labels beat raw UUIDs
         sources=build_sources(agent_chunks),
+        model_used=result.get("model"),
+        model_alias=result.get("model_alias"),
+        fallback_from=result.get("fallback_from"),
     )

--- a/rag_orchestrator/tests/test_models_passthrough.py
+++ b/rag_orchestrator/tests/test_models_passthrough.py
@@ -1,0 +1,84 @@
+# rag_orchestrator/tests/test_models_passthrough.py
+"""
+WP-M5: the orchestrator exposes llm_service's model menu and surfaces
+the model actually used in RAG responses.
+"""
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+import src.api.v1.routes as routes
+from src.api.v1.main import app
+from src.core.service import RAGResult
+
+pytestmark = pytest.mark.unit
+
+
+def test_models_passthrough(monkeypatch):
+    menu = {
+        "models": [
+            {"alias": "default", "model": "ollama/phi4-mini:latest",
+             "is_default": True},
+            {"alias": "smart", "model": "anthropic/claude-sonnet-5",
+             "is_default": False},
+        ],
+        "default": "default",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/models"
+        return httpx.Response(200, json=menu)
+
+    real_async_client = httpx.AsyncClient
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+    client = TestClient(app)
+    response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    assert response.json() == menu
+
+
+def test_models_passthrough_502_when_llm_service_down(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("down")
+
+    real_async_client = httpx.AsyncClient
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+    client = TestClient(app)
+    assert client.get("/v1/models").status_code == 502
+
+
+def test_rag_response_carries_model_metadata(monkeypatch):
+    async def fake_run_rag(**kwargs):
+        return RAGResult(
+            answer="ok",
+            sources=[],
+            repo_id="repo-x",
+            retrieval_plan={},
+            model_used="openai/gpt-5.1",
+            model_alias="smart",
+            fallback_from="anthropic/claude-sonnet-5",
+        )
+
+    monkeypatch.setattr(routes, "run_rag", fake_run_rag)
+
+    client = TestClient(app)
+    response = client.post("/v1/rag", json={"query": "q", "repo_id": "repo-x"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["model_used"] == "openai/gpt-5.1"
+    assert body["model_alias"] == "smart"
+    assert body["fallback_from"] == "anthropic/claude-sonnet-5"


### PR DESCRIPTION
Phase 2 Track B, follows #36 (WP-M2). Completes the user's WP-M1 → M2 → M5 sequence.

- **llm_service**: `GET /v1/models` lists aliases (`alias`/`model`/`is_default`) + the default; `/v1/summarize/{id}` honors `provider`/`model` params (previously hardcoded phi4-mini, bypassing configuration).
- **rag_orchestrator**: `GET /v1/models` passthrough (Gradio only reaches ingestion + orchestrator; 502 with a clear message if llm_service is down). `RAGResponse`/`SimpleRAGResponse` gain optional `model_used`/`model_alias`/`fallback_from` — answer metadata shows the model actually used, including WP-M2 fallbacks. Existing fields unchanged.
- **Gradio**: model free-text fields → dropdowns fed from `/v1/models` on load, `allow_custom_value=True` keeps raw `provider/model` strings working; answers display the model used and any fallback.

Acceptance criteria: `GET /v1/models` lists aliases + default ✅ · dropdown switches models & answer metadata shows model used ✅ (dropdown fed by menu; metadata asserted in tests) · summarize honors model alias ✅.

llm_service 28 passed, orchestrator 67 passed.