### PR TITLE
Issue #28: re-enable ruff E501, mechanical reformat

### DIFF
--- a/DOCS/test_results/phase1_benchmark.py
+++ b/DOCS/test_results/phase1_benchmark.py
@@ -17,7 +17,7 @@ docker-compose.test.yml Postgres, plus real-Ollama embedding throughput
                                           synthetic rows, filtered query)
 
 Usage (from ingestion_service/, root venv, test DB up + migrated):
-  DATABASE_URL=postgresql://ingestion_user:ingestion_pass@localhost:5433/ingestion_test \
+DATABASE_URL=postgresql://ingestion_user:ingestion_pass@localhost:5433/ingestion_test \
     ../.venv/Scripts/python.exe ../DOCS/test_results/phase1_benchmark.py
 """
 import json

--- a/ingestion_service/src/api/v1/codebase_ingest.py
+++ b/ingestion_service/src/api/v1/codebase_ingest.py
@@ -144,7 +144,8 @@ def _background_ingest_repo(
     provider: str | None,
 ):
     """
-    Clone or use local repo, build graph, persist nodes & relationships, and embed code artifacts.
+    Clone or use local repo, build graph, persist nodes &
+    relationships, and embed code artifacts.
     """
     session = SessionLocal()
     StatusManager(session).mark_running(ingestion_id)
@@ -152,7 +153,10 @@ def _background_ingest_repo(
     temp_dir = None
     try:
         logger.debug(f"[{ingestion_id}] Starting background ingestion")
-        logger.debug(f"[{ingestion_id}] git_url={git_url}, local_path={local_path}, provider={provider}")
+        logger.debug(
+            f"[{ingestion_id}] git_url={git_url}, "
+            f"local_path={local_path}, provider={provider}"
+        )
 
         if git_url:
             import git  # GitPython
@@ -167,20 +171,30 @@ def _background_ingest_repo(
             repo_id_url = repo_path
         else:
             raise ValueError("Either git_url or local_path must be provided")
-        logger.debug(f"build_repo_id({repo_id_url}) calculates repo_id = {build_repo_id(repo_id_url)}")
+        logger.debug(
+            f"build_repo_id({repo_id_url}) calculates "
+            f"repo_id = {build_repo_id(repo_id_url)}"
+        )
         repo_id = build_repo_id(repo_id_url)
 
         # --- Build Repo Graph ---
         logger.debug(f"[{ingestion_id}] Building RepoGraph...")
-        builder = RepoGraphBuilder(repo_root=Path(repo_path), ingestion_id=str(ingestion_id))
+        builder = RepoGraphBuilder(
+            repo_root=Path(repo_path), ingestion_id=str(ingestion_id)
+        )
         repo_graph = builder.build()
         logger.debug(f"[{ingestion_id}] RepoGraph built successfully")
 
-        logger.debug(f"[{ingestion_id}] Total entities: {len(repo_graph.all_entities())}")
+        logger.debug(
+            f"[{ingestion_id}] Total entities: {len(repo_graph.all_entities())}"
+        )
         # --- Persist Nodes & Relationships ---
         persistence = CodebaseGraphPersistence(session=session)
         nodes = repo_graph.all_entities()  # ✅ CORRECT method
-        logger.debug(f"[{ingestion_id}] Sample node keys: {nodes[0].keys() if nodes else 'NO NODES'}")
+        logger.debug(
+            f"[{ingestion_id}] Sample node keys: "
+            f"{nodes[0].keys() if nodes else 'NO NODES'}"
+        )
         # F-09/F-06: delete + nodes + relationships in one transaction,
         # serialized per repo by an advisory lock.
         stats = persistence.persist_graph(
@@ -225,14 +239,20 @@ def _background_ingest_repo(
 # -----------------------------
 # POST /v1/codebase/ingest-repo
 # -----------------------------
-@router.post("/ingest-repo", response_model=RepoIngestResponse, status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/ingest-repo",
+    response_model=RepoIngestResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
 def ingest_repo(
     git_url: str | None = Form(default=None),
     local_path: str | None = Form(default=None),
     provider: str | None = Form(default=None),
 ) -> RepoIngestResponse:
     if not git_url and not local_path:
-        raise HTTPException(status_code=400, detail="Must provide either git_url or local_path")
+        raise HTTPException(
+            status_code=400, detail="Must provide either git_url or local_path"
+        )
 
     ingestion_id = uuid4()
     metadata = {"git_url": git_url, "local_path": local_path, "provider": provider}
@@ -275,9 +295,14 @@ def get_repo_ingest_status(ingestion_id: str) -> RepoIngestResponse:
         raise HTTPException(status_code=400, detail="Invalid ingestion ID format")
 
     with SessionLocal() as session:
-        request = session.query(IngestionRequest).filter_by(ingestion_id=ingestion_uuid).first()
+        request = (
+            session.query(IngestionRequest)
+            .filter_by(ingestion_id=ingestion_uuid)
+            .first()
+        )
         if not request:
             raise HTTPException(status_code=404, detail="Ingestion ID not found")
 
-        return RepoIngestResponse(ingestion_id=request.ingestion_id, status=request.status)
-
+        return RepoIngestResponse(
+            ingestion_id=request.ingestion_id, status=request.status
+        )

--- a/ingestion_service/src/api/v1/ingest.py
+++ b/ingestion_service/src/api/v1/ingest.py
@@ -79,7 +79,14 @@ def extract_text_from_bytes(
         return ocr_engine.extract_text(file_bytes) or ""
 
     # Text files → robust multi-encoding decoder
-    encodings = ["utf-8", "utf-8-sig", "windows-1252", "latin-1", "cp1252", "iso-8859-1"]
+    encodings = [
+        "utf-8",
+        "utf-8-sig",
+        "windows-1252",
+        "latin-1",
+        "cp1252",
+        "iso-8859-1",
+    ]
     for encoding in encodings:
         try:
             text = file_bytes.decode(encoding)
@@ -218,7 +225,9 @@ def background_ingest_file(  # noqa: C901 - refactor tracked by pipeline-factory
                 ocr_provider=None,
             )
             if not text.strip():
-                raise RuntimeError("No extractable text found in uploaded Markdown file")
+                raise RuntimeError(
+                    "No extractable text found in uploaded Markdown file"
+                )
             pipeline.run_with_sections(
                 source=text,
                 ingestion_id=str(ingestion_id),

--- a/ingestion_service/src/core/codebase/codebase_persistence.py
+++ b/ingestion_service/src/core/codebase/codebase_persistence.py
@@ -50,7 +50,9 @@ class CodebaseGraphPersistence:
         """
         try:
             # Count before deletion
-            pre_count = self._session.query(DocumentNode).filter_by(repo_id=repo_id).count()
+            pre_count = (
+                self._session.query(DocumentNode).filter_by(repo_id=repo_id).count()
+            )
             if pre_count == 0:
                 logger.info(f"[MS12] Repo {repo_id}: no nodes to delete")
                 return 0
@@ -62,7 +64,9 @@ class CodebaseGraphPersistence:
                 .delete(synchronize_session=False)
             )
             self._session.commit()
-            logger.info(f"[MS12] Repo {repo_id}: deleted {deleted_count} old document nodes")
+            logger.info(
+                f"[MS12] Repo {repo_id}: deleted {deleted_count} old document nodes"
+            )
             return deleted_count
         except SQLAlchemyError as e:
             logger.error(f"[MS12] Error deleting nodes for repo {repo_id}: {e}")
@@ -199,7 +203,9 @@ class CodebaseGraphPersistence:
     # -----------------------------
     # Retrieval
     # -----------------------------
-    def get_node_by_canonical_id(self, repo_id: str, canonical_id: str) -> Optional[DocumentNode]:
+    def get_node_by_canonical_id(
+        self, repo_id: str, canonical_id: str
+    ) -> Optional[DocumentNode]:
         """
         Retrieve a document node by repo_id + canonical_id.
         """

--- a/ingestion_service/src/core/codebase/identity.py
+++ b/ingestion_service/src/core/codebase/identity.py
@@ -17,8 +17,10 @@ def build_canonical_id(
     Build a deterministic canonical ID for an artifact.
 
     Args:
-        relative_path: path relative to repository root (forward slashes, no leading slash)
-        symbol_path: optional dot-separated symbol path (for classes, functions, methods)
+        relative_path: path relative to repository root
+            (forward slashes, no leading slash)
+        symbol_path: optional dot-separated symbol path
+            (for classes, functions, methods)
 
     Returns:
         canonical_id: deterministic string
@@ -30,7 +32,9 @@ def build_canonical_id(
     return path_clean
 
 
-def build_global_id(repo_id: str, relative_path: str, symbol_path: str | None = None) -> tuple[str, str]:
+def build_global_id(
+    repo_id: str, relative_path: str, symbol_path: str | None = None
+) -> tuple[str, str]:
     """
     Returns a tuple (repo_id, canonical_id) suitable for storage in document_nodes.
 

--- a/ingestion_service/src/core/converters/docling_converter.py
+++ b/ingestion_service/src/core/converters/docling_converter.py
@@ -96,7 +96,8 @@ class DoclingConverter:
 
         Args:
             file_bytes: Raw bytes of the source file
-            filename:   Original filename including extension (used for format detection)
+            filename:   Original filename including extension
+                (used for format detection)
 
         Returns:
             Markdown string of the document content
@@ -113,7 +114,9 @@ class DoclingConverter:
                 f"Supported: {DOCLING_SUPPORTED}"
             )
 
-        logger.debug("IS3: Converting %s (%d bytes) via Docling", filename, len(file_bytes))
+        logger.debug(
+            "IS3: Converting %s (%d bytes) via Docling", filename, len(file_bytes)
+        )
 
         try:
             stream = DocumentStream(

--- a/ingestion_service/src/core/crud/crud_document_node.py
+++ b/ingestion_service/src/core/crud/crud_document_node.py
@@ -41,9 +41,12 @@ def create_document_node(
         summary = "Summary pending"  # Default summary if not provided
 
     # Log the data to check before insertion
-    logger.debug(f"Creating DocumentNode with data: "
-                 f"document_id={document_id}, title={title}, summary={summary}, "
-                 f"source={source}, ingestion_id={ingestion_id}, doc_type={doc_type}, repo_id={repo_id}")
+    logger.debug(
+        f"Creating DocumentNode with data: "
+        f"document_id={document_id}, title={title}, summary={summary}, "
+        f"source={source}, ingestion_id={ingestion_id}, "
+        f"doc_type={doc_type}, repo_id={repo_id}"
+    )
 
     # Create and persist the DocumentNode
     node = DocumentNode(

--- a/ingestion_service/src/core/crud/document_relationships.py
+++ b/ingestion_service/src/core/crud/document_relationships.py
@@ -95,7 +95,9 @@ def delete_document_relationship(
     session.query(DocumentRelationship).filter_by(id=relationship_id).delete()
     session.flush()
 
-def list_outgoing_relationships(session: Session, document_id: str) -> list[DocumentRelationship]:
+def list_outgoing_relationships(
+    session: Session, document_id: str
+) -> list[DocumentRelationship]:
     """
     Return all outgoing relationships from a given document.
 
@@ -106,4 +108,8 @@ def list_outgoing_relationships(session: Session, document_id: str) -> list[Docu
     Returns:
         List of DocumentRelationship instances where `from_document_id` == document_id
     """
-    return session.query(DocumentRelationship).filter_by(from_document_id=document_id).all()
+    return (
+        session.query(DocumentRelationship)
+        .filter_by(from_document_id=document_id)
+        .all()
+    )

--- a/ingestion_service/src/core/extractors/markdown_extractor.py
+++ b/ingestion_service/src/core/extractors/markdown_extractor.py
@@ -29,7 +29,8 @@ logger = logging.getLogger(__name__)
 class MarkdownSectionExtractor:
     """
     Extracts MARKDOWN_MODULE and MARKDOWN_SECTION artifacts from a .md file.
-    Returns same List[Dict] shape as PythonASTExtractor for RepoGraphBuilder compatibility.
+    Returns same List[Dict] shape as PythonASTExtractor for
+    RepoGraphBuilder compatibility.
     """
 
     def __init__(self, relative_path: str):
@@ -120,7 +121,8 @@ class MarkdownSectionExtractor:
                     heading_stack.pop()
                 heading_stack.append((level, canonical_id, slug))
 
-                # Find section text: from this heading line to next same-or-higher heading
+                # Find section text: from this heading line to the
+                # next same-or-higher heading
                 section_text = self._slice_section_text(
                     lines, lineno, level, tokens, i
                 )

--- a/ingestion_service/src/core/extractors/python_extractor.py
+++ b/ingestion_service/src/core/extractors/python_extractor.py
@@ -93,7 +93,9 @@ class PythonASTExtractor(ast.NodeVisitor):
             "metadata": {
                 "lineno": node.lineno,
                 "col_offset": node.col_offset,
-                "bases": [ast.unparse(base) for base in node.bases] if node.bases else [],
+                "bases": [ast.unparse(base) for base in node.bases]
+                if node.bases
+                else [],
             },
         }
 

--- a/ingestion_service/src/core/graph_utils.py
+++ b/ingestion_service/src/core/graph_utils.py
@@ -27,12 +27,22 @@ class Node:
     """
     Represents a single artifact node in the graph.
     """
-    def __init__(self, canonical_id: str, file_path: Optional[str] = None, lineno: Optional[int] = None):
+
+    def __init__(
+        self,
+        canonical_id: str,
+        file_path: Optional[str] = None,
+        lineno: Optional[int] = None,
+    ):
         self.canonical_id = canonical_id
         self.file_path = file_path
         self.lineno = lineno
-        self.out_edges: Dict[str, Set['Node']] = defaultdict(set)  # relation_type -> set of target nodes
-        self.in_edges: Dict[str, Set['Node']] = defaultdict(set)   # relation_type -> set of source nodes
+        self.out_edges: Dict[str, Set["Node"]] = defaultdict(
+            set
+        )  # relation_type -> set of target nodes
+        self.in_edges: Dict[str, Set["Node"]] = defaultdict(
+            set
+        )  # relation_type -> set of source nodes
 
     def __repr__(self):
         return f"Node({self.canonical_id})"
@@ -72,7 +82,8 @@ _repo_graphs: Dict[str, CodebaseGraph] = {}
 
 def load_graph_for_repo(repo_id: str, db: Session) -> CodebaseGraph:
     """
-    Build an in-memory CodebaseGraph from persisted DocumentNode and DocumentRelationship entries.
+    Build an in-memory CodebaseGraph from persisted DocumentNode
+    and DocumentRelationship entries.
     """
     graph = CodebaseGraph()
 
@@ -106,7 +117,9 @@ def load_graph_for_repo(repo_id: str, db: Session) -> CodebaseGraph:
     return graph
 
 
-def canonical_ids_to_document_ids(repo_id: str, canonical_ids: Set[str], db: Session) -> Set[str]:
+def canonical_ids_to_document_ids(
+    repo_id: str, canonical_ids: Set[str], db: Session
+) -> Set[str]:
     """
     Convert canonical_ids → document_ids for a repo.
     """
@@ -121,11 +134,16 @@ def canonical_ids_to_document_ids(repo_id: str, canonical_ids: Set[str], db: Ses
         .all()
     }
 
-    logger.debug(f"Resolved {len(canonical_ids)} canonical_ids → {len(document_ids)} document_ids")
+    logger.debug(
+        f"Resolved {len(canonical_ids)} canonical_ids → "
+        f"{len(document_ids)} document_ids"
+    )
     return document_ids
 
 
-def get_cached_graph(repo_id: str, db: Session, force_reload: bool = False) -> CodebaseGraph:
+def get_cached_graph(
+    repo_id: str, db: Session, force_reload: bool = False
+) -> CodebaseGraph:
     """
     Return a CodebaseGraph for the given repo_id, using an in-memory cache.
     """

--- a/ingestion_service/src/core/pipeline.py
+++ b/ingestion_service/src/core/pipeline.py
@@ -53,7 +53,10 @@ class IngestionPipeline:
 
         Use this for simple text ingestion (TXT files).
         """
-        logger.debug("🔄 pipeline.py run() - TEXT PATH - Full MS6 pipeline: validate → chunk → DocumentNode → embed → persist")
+        logger.debug(
+            "🔄 pipeline.py run() - TEXT PATH - Full MS6 pipeline: "
+            "validate → chunk → DocumentNode → embed → persist"
+        )
 
         # MS6: Create DocumentNode FIRST (before any vectors)
         sessionmaker = get_sessionmaker()
@@ -61,13 +64,16 @@ class IngestionPipeline:
             document_id = uuid4()
             # 🔥 MS7 FIX: Use exact source format that summary.py expects
             source = f"file_document_{ingestion_id}"  # Full UUID to match summary.py
-            title = f"{source_type}_document_{ingestion_id[:8]}"  # Keep title human-readable
+            # Keep title human-readable
+            title = f"{source_type}_document_{ingestion_id[:8]}"
 
             logger.debug("📝 MS6 run() Creating DocumentNode:")
             logger.debug(f"   ingestion_id: {ingestion_id}")
             logger.debug(f"   document_id: {document_id}")
             logger.debug(f"   title: '{title}'")
-            logger.debug(f"   source: '{source}'")  # 🔥 MS7: This MUST match summary.py query
+            logger.debug(
+                f"   source: '{source}'"
+            )  # 🔥 MS7: This MUST match summary.py query
             relative_path = filename or "uploaded_file"
             canonical_id = f"{source_type}_document_{ingestion_id}"
             create_document_node(
@@ -83,7 +89,9 @@ class IngestionPipeline:
                 repo_id=str(ingestion_id),
             )
             session.commit()  #  CRITICAL: Commit BEFORE vectors
-            logger.debug(f"✅ MS6 run() DocumentNode COMMITTED {document_id} for {ingestion_id}")
+            logger.debug(
+                f"✅ MS6 run() DocumentNode COMMITTED {document_id} for {ingestion_id}"
+            )
             logger.debug(f"   → summary.py will look for source='{source}'")
 
         # Continue normal pipeline
@@ -97,7 +105,10 @@ class IngestionPipeline:
             canonical_id=canonical_id,                # ADD
         )
         embeddings = self._embed(chunks)
-        logger.debug(f"📦 MS6 run() Persisting {len(chunks)} chunks with document_id={document_id}")
+        logger.debug(
+            f"📦 MS6 run() Persisting {len(chunks)} chunks "
+            f"with document_id={document_id}"
+        )
         self._persist(chunks, embeddings, ingestion_id, str(document_id))
 
     def run_with_chunks(
@@ -112,7 +123,10 @@ class IngestionPipeline:
         Pipeline for pre-chunked content: DocumentNode → embed → persist (MS6).
         Use this for PDFs or other content where chunking happened upstream.
         """
-        logger.debug(f"🔄 pipeline.py run_with_chunks() - PDF PATH - {len(chunks)} pre-chunked items")
+        logger.debug(
+            f"🔄 pipeline.py run_with_chunks() - PDF PATH - "
+            f"{len(chunks)} pre-chunked items"
+        )
 
         # MS6: Create DocumentNode FIRST
         sessionmaker = get_sessionmaker()
@@ -120,13 +134,17 @@ class IngestionPipeline:
             document_id = uuid4()
             # 🔥 MS7 FIX: Use exact source format that summary.py expects
             source = f"file_document_{ingestion_id}"  # Full UUID to match summary.py
-            title = chunks[0].metadata.get("filename", "untitled") if chunks else "untitled"
+            title = (
+                chunks[0].metadata.get("filename", "untitled") if chunks else "untitled"
+            )
 
             logger.debug("📝 MS6 run_with_chunks() Creating DocumentNode:")
             logger.debug(f"   ingestion_id: {ingestion_id}")
             logger.debug(f"   document_id: {document_id}")
             logger.debug(f"   title: '{title}'")
-            logger.debug(f"   source: '{source}'")  # 🔥 MS7: This MUST match summary.py query
+            logger.debug(
+                f"   source: '{source}'"
+            )  # 🔥 MS7: This MUST match summary.py query
             relative_path = filename or "uploaded_file"
             canonical_id = f"pdf_document_{ingestion_id}"
             create_document_node(
@@ -142,7 +160,10 @@ class IngestionPipeline:
                 repo_id=str(ingestion_id),
                 )
             session.commit()  # 🔥 CRITICAL: Commit BEFORE vectors
-            logger.debug(f"✅ MS6 run_with_chunks() DocumentNode COMMITTED {document_id} for {ingestion_id}")
+            logger.debug(
+                f"✅ MS6 run_with_chunks() DocumentNode COMMITTED "
+                f"{document_id} for {ingestion_id}"
+            )
             logger.debug(f"   → summary.py will look for source='{source}'")
 
             # Inject metadata into pre-built chunks — these bypass _chunk()
@@ -157,7 +178,10 @@ class IngestionPipeline:
 
         # Continue pipeline
         embeddings = self._embed(chunks)
-        logger.debug(f"📦 MS6 run_with_chunks() Persisting {len(chunks)} chunks with document_id={document_id}")
+        logger.debug(
+            f"📦 MS6 run_with_chunks() Persisting {len(chunks)} chunks "
+            f"with document_id={document_id}"
+        )
         self._persist(chunks, embeddings, ingestion_id, str(document_id))
 
     def embed_and_persist_batch(
@@ -208,7 +232,9 @@ class IngestionPipeline:
         Chunk text using selected strategy.
         Adds provenance metadata to each chunk for provenance.
         """
-        logger.debug(f"🔪 pipeline.py _chunk() text_len={len(text)} source_type={source_type}")
+        logger.debug(
+            f"🔪 pipeline.py _chunk() text_len={len(text)} source_type={source_type}"
+        )
 
         if self._chunker is None:
             selected_chunker, chunker_params = ChunkerFactory.choose_strategy(text)
@@ -219,7 +245,10 @@ class IngestionPipeline:
         chunks: list[Chunk] = selected_chunker.chunk(text, **chunker_params)
         chunk_strategy = getattr(selected_chunker, "chunk_strategy", "unknown")
 
-        logger.debug(f"   → Selected chunker: {getattr(selected_chunker, 'name', selected_chunker.__class__.__name__)}")
+        chunker_name = getattr(
+            selected_chunker, "name", selected_chunker.__class__.__name__
+        )
+        logger.debug(f"   → Selected chunker: {chunker_name}")
         logger.debug(f"   → Strategy: {chunk_strategy}, Chunks produced: {len(chunks)}")
 
         # Add provenance metadata to each chunk
@@ -257,7 +286,10 @@ class IngestionPipeline:
                 f"Embedder mismatch: {len(chunks)} chunks, {len(embeddings)} embeddings"
             )
 
-        logger.debug(f"✅ _embed() produced {len(embeddings)} embeddings ({len(embeddings[0])} dims each)")
+        logger.debug(
+            f"✅ _embed() produced {len(embeddings)} embeddings "
+            f"({len(embeddings[0])} dims each)"
+        )
         return embeddings
 
     def _persist(
@@ -270,7 +302,9 @@ class IngestionPipeline:
         """
         Persist chunks and embeddings to vector store.
         """
-        logger.debug(f"💾 pipeline.py _persist() {len(chunks)} chunks doc_id={document_id}")
+        logger.debug(
+            f"💾 pipeline.py _persist() {len(chunks)} chunks doc_id={document_id}"
+        )
         logger.debug(f"   → ingestion_id: {ingestion_id}")
         self._vector_store.persist(
             chunks=chunks,

--- a/ingestion_service/src/ui/gradio_app.py
+++ b/ingestion_service/src/ui/gradio_app.py
@@ -37,7 +37,10 @@ def submit_ingest(source_type: str, file_obj):
             return f"Error submitting ingestion: {response.text}"
 
         data = response.json()
-        return f"Ingestion accepted.\nID: {data['ingestion_id']}\nStatus: {data.get('status', '-')}"
+        return (
+            f"Ingestion accepted.\nID: {data['ingestion_id']}\n"
+            f"Status: {data.get('status', '-')}"
+        )
     except Exception as exc:
         return f"Error submitting ingestion: {exc}"
 
@@ -72,7 +75,9 @@ def check_status(ingestion_id: str):
 # ----------------------------
 # Codebase Ingestion Functions (unchanged)
 # ----------------------------
-def submit_codebase_ingest(source_type: str, git_url: str, local_path: str, provider: str):
+def submit_codebase_ingest(
+    source_type: str, git_url: str, local_path: str, provider: str
+):
     """Submit codebase ingestion request."""
     print(f"🔍 Gradio calling: {API_BASE_URL}/v1/ingest-repo")
     try:
@@ -99,7 +104,10 @@ def submit_codebase_ingest(source_type: str, git_url: str, local_path: str, prov
             return f"Error: {response.text}"
 
         data = response.json()
-        return f"✅ **Ingestion Started**\nID: `{data['ingestion_id']}`\nStatus: {data['status']}\n\n*Check status below*"
+        return (
+            f"✅ **Ingestion Started**\nID: `{data['ingestion_id']}`\n"
+            f"Status: {data['status']}\n\n*Check status below*"
+        )
 
     except Exception as exc:
         return f"❌ Error: {exc}"
@@ -185,7 +193,9 @@ def _model_line(data: dict) -> str:
     return line
 
 
-def submit_rag_query(query: str, repo_id: str | None, top_k: int, provider: str | None, model: str | None):
+def submit_rag_query(
+    query: str, repo_id: str | None, top_k: int, provider: str | None, model: str | None
+):
     """Submit RAG query with repo_id."""
     try:
         if not query.strip():
@@ -227,7 +237,10 @@ def submit_rag_query(query: str, repo_id: str | None, top_k: int, provider: str 
 
     except requests.exceptions.HTTPError as e:
         if e.response.status_code == 404:
-            return "❌ Repository not found. Refresh repos and select a complete repository."
+            return (
+                "❌ Repository not found. "
+                "Refresh repos and select a complete repository."
+            )
         try:
             return f"❌ RAG Error: {e.response.json().get('detail', e.response.text)}"
         except Exception:
@@ -235,7 +248,9 @@ def submit_rag_query(query: str, repo_id: str | None, top_k: int, provider: str 
     except Exception as exc:
         return f"❌ Error querying RAG: {exc}"
 
-def submit_simple_rag_query(query: str, top_k: int, provider: str | None, model: str | None):
+def submit_simple_rag_query(
+    query: str, top_k: int, provider: str | None, model: str | None
+):
     """Submit a simple (non-graph) RAG query for regular documents."""
     try:
         if not query.strip():
@@ -330,11 +345,18 @@ def build_ui():
             )
             codebase_submit_btn = gr.Button("💾 Ingest Codebase", variant="secondary")  # type: ignore
 
-        codebase_submission_output = gr.Textbox(label="Codebase Submission Result", lines=2)  # type: ignore
+        codebase_submission_output = gr.Textbox(
+            label="Codebase Submission Result", lines=2
+        )  # type: ignore
 
         codebase_submit_btn.click(
             fn=submit_codebase_ingest,
-            inputs=[codebase_source_type, git_url_input, local_path_input, provider_input],
+            inputs=[
+                codebase_source_type,
+                git_url_input,
+                local_path_input,
+                provider_input,
+            ],
             outputs=codebase_submission_output,
         )
 
@@ -353,7 +375,10 @@ def build_ui():
         # 3. REPO-AWARE RAG (NEW SECTION)
         # ----------------------------
         gr.Markdown("## 🎯 Graph-Aware RAG Query")
-        gr.Markdown("*Ask about code structure: 'methods in math_utils.py', 'what calls add()', etc.*")
+        gr.Markdown(
+            "*Ask about code structure: 'methods in math_utils.py', "
+            "'what calls add()', etc.*"
+        )
 
         with gr.Row():  # type: ignore
             repo_dropdown = gr.Dropdown(
@@ -366,7 +391,8 @@ def build_ui():
 
         rag_query = gr.Textbox(  # type: ignore
             label="❓ Question",
-            placeholder="e.g. 'methods in math_utils.py', 'what calls add()', or general questions...",
+            placeholder="e.g. 'methods in math_utils.py', "
+            "'what calls add()', or general questions...",
             lines=3,
         )
 
@@ -410,7 +436,9 @@ def build_ui():
         )
 
         with gr.Row():
-            doc_top_k = gr.Number(label="📊 Top K", value=5, precision=0, minimum=1, maximum=50)
+            doc_top_k = gr.Number(
+                label="📊 Top K", value=5, precision=0, minimum=1, maximum=50
+            )
             doc_provider = gr.Textbox(label="🤖 LLM Provider", placeholder="ollama")
             doc_model = gr.Dropdown(
                 label="🧠 Model",

--- a/ingestion_service/tests/codebase/test_python_extractor.py
+++ b/ingestion_service/tests/codebase/test_python_extractor.py
@@ -36,8 +36,15 @@ def test_extractor_on_self_file(extractor):
     method_artifacts = [a for a in artifacts if a["artifact_type"] == "METHOD"]
     method_names = [m["name"] for m in method_artifacts]
     # Methods inside PythonASTExtractor
-    expected_methods = ["extract", "visit_ClassDef", "visit_FunctionDef", "visit_Import",
-                        "visit_ImportFrom", "visit_Call", "_get_parent_class"]
+    expected_methods = [
+        "extract",
+        "visit_ClassDef",
+        "visit_FunctionDef",
+        "visit_Import",
+        "visit_ImportFrom",
+        "visit_Call",
+        "_get_parent_class",
+    ]
     for method in expected_methods:
         assert method in method_names
 
@@ -54,7 +61,11 @@ def test_extractor_on_self_file(extractor):
     # -----------------------------
     import_artifacts = [a for a in artifacts if a["artifact_type"] == "IMPORT"]
     import_names = [i["name"] for i in import_artifacts]
-    import_modules = [i.get("metadata", {}).get("module") for i in import_artifacts if "module" in i.get("metadata", {})]
+    import_modules = [
+        i.get("metadata", {}).get("module")
+        for i in import_artifacts
+        if "module" in i.get("metadata", {})
+    ]
 
     # Check standard imports
     assert "ast" in import_names  # from 'import ast'

--- a/ingestion_service/tests/core/test_identity.py
+++ b/ingestion_service/tests/core/test_identity.py
@@ -9,5 +9,7 @@ def test_build_canonical_id_with_symbol():
     assert cid == "src/module.py#MyClass.my_method"
 
 def test_build_global_id():
-    gid = build_global_id("123e4567-e89b-12d3-a456-426614174000", "src/module.py", "func")
+    gid = build_global_id(
+        "123e4567-e89b-12d3-a456-426614174000", "src/module.py", "func"
+    )
     assert gid == ("123e4567-e89b-12d3-a456-426614174000", "src/module.py#func")

--- a/ingestion_service/tests/core/test_repo_naming.py
+++ b/ingestion_service/tests/core/test_repo_naming.py
@@ -48,10 +48,15 @@ def test_same_repo_name_different_owners_stay_distinguishable():
 
 
 def test_windows_local_path():
-    identity = derive_repo_identity({"local_path": "C:\\Users\\bosto\\repos\\my_test_repo"})
+    identity = derive_repo_identity(
+        {"local_path": "C:\\Users\\bosto\\repos\\my_test_repo"}
+    )
     assert identity["source_type"] == "local"
     assert identity["name"] == "my_test_repo"
-    assert identity["display_name"] == "my_test_repo — C:\\Users\\bosto\\repos\\my_test_repo"
+    assert (
+        identity["display_name"]
+        == "my_test_repo — C:\\Users\\bosto\\repos\\my_test_repo"
+    )
     assert identity["git_url"] is None
 
 

--- a/ingestion_service/tests/test_crud_document_relationships.py
+++ b/ingestion_service/tests/test_crud_document_relationships.py
@@ -91,21 +91,31 @@ def test_list_relationships(session, sample_document):
     session.flush()
 
     # Create two relationships
-    rel1 = crud.create_document_relationship(session, doc1.document_id, doc2.document_id, "supports")
-    rel2 = crud.create_document_relationship(session, doc2.document_id, doc1.document_id, "refutes")
+    rel1 = crud.create_document_relationship(
+        session, doc1.document_id, doc2.document_id, "supports"
+    )
+    rel2 = crud.create_document_relationship(
+        session, doc2.document_id, doc1.document_id, "refutes"
+    )
 
     # Test outgoing
-    outgoing = crud.list_relationships_for_document(session, doc1.document_id, outgoing=True, incoming=False)
+    outgoing = crud.list_relationships_for_document(
+        session, doc1.document_id, outgoing=True, incoming=False
+    )
     assert rel1 in outgoing
     assert rel2 not in outgoing
 
     # Test incoming
-    incoming = crud.list_relationships_for_document(session, doc1.document_id, outgoing=False, incoming=True)
+    incoming = crud.list_relationships_for_document(
+        session, doc1.document_id, outgoing=False, incoming=True
+    )
     assert rel2 in incoming
     assert rel1 not in incoming
 
     # Test all
-    all_rels = crud.list_relationships_for_document(session, doc1.document_id, outgoing=True, incoming=True)
+    all_rels = crud.list_relationships_for_document(
+        session, doc1.document_id, outgoing=True, incoming=True
+    )
     assert set(all_rels) == {rel1, rel2}
 
 
@@ -121,7 +131,9 @@ def test_delete_relationship(session, sample_document):
     session.add(doc2)
     session.flush()
 
-    rel = crud.create_document_relationship(session, doc1.document_id, doc2.document_id, "supports")
+    rel = crud.create_document_relationship(
+        session, doc1.document_id, doc2.document_id, "supports"
+    )
     rel_id = rel.id
 
     crud.delete_document_relationship(session, rel_id)

--- a/ingestion_service/tests/test_db_migration_v2.py
+++ b/ingestion_service/tests/test_db_migration_v2.py
@@ -13,4 +13,6 @@ def test_document_nodes_table_exists_sql():
             """
         )
         tables = [row[0] for row in result]
-    assert "document_nodes" in tables, f"'document_nodes' table not found. Found: {tables}"
+    assert "document_nodes" in tables, (
+        f"'document_nodes' table not found. Found: {tables}"
+    )

--- a/ingestion_service/tests/test_relationship_persistence.py
+++ b/ingestion_service/tests/test_relationship_persistence.py
@@ -73,10 +73,14 @@ def test_document_relationship_crud(session: Session):
     session.commit()
 
     # Add a relationship
-    create_document_relationship(session, node1.document_id, node2.document_id, "supports")
+    create_document_relationship(
+        session, node1.document_id, node2.document_id, "supports"
+    )
     session.commit()
 
     # Attempt to insert duplicate
     with pytest.raises(IntegrityError):
-        create_document_relationship(session, node1.document_id, node2.document_id, "supports")
+        create_document_relationship(
+            session, node1.document_id, node2.document_id, "supports"
+        )
         session.commit()

--- a/llm_service/src/api/v1/summarize.py
+++ b/llm_service/src/api/v1/summarize.py
@@ -74,7 +74,9 @@ async def generate_summary(
         # 1. Fetch chunks from ingestion_service (not vector store)
         chunk_texts = await fetch_chunks(ingestion_id)
         if not chunk_texts:
-            raise HTTPException(status_code=404, detail="No chunks found for ingestion_id")
+            raise HTTPException(
+                status_code=404, detail="No chunks found for ingestion_id"
+            )
 
         # 2. Join top 5 chunks, truncate if needed
         full_text = "\n\n".join(chunk_texts[:5])
@@ -84,7 +86,10 @@ async def generate_summary(
         # 3. Build prompt
         logger.info("Build prompt")
         context = f"Document chunks for summarization:\n\n{full_text}"
-        query = "Summarize this document in 2-3 sentences. Focus on main topics, key entities, and purpose."
+        query = (
+            "Summarize this document in 2-3 sentences. "
+            "Focus on main topics, key entities, and purpose."
+        )
 
         # 4. Call LLM
         logger.info("summarize.py call generate_completion")

--- a/migrations/versions/20260131_add_documentnodes_table.py
+++ b/migrations/versions/20260131_add_documentnodes_table.py
@@ -30,7 +30,8 @@ def upgrade() -> None:
         summary TEXT NOT NULL,
         summary_embedding vector(768),
         source TEXT NOT NULL,
-        ingestion_id UUID NOT NULL REFERENCES ingestion_service.ingestion_requests(ingestion_id),
+        ingestion_id UUID NOT NULL
+            REFERENCES ingestion_service.ingestion_requests(ingestion_id),
         doc_type TEXT NOT NULL,
         text TEXT
     )
@@ -43,10 +44,17 @@ def upgrade() -> None:
     """)
 
     # Create indexes for performance
-    op.execute("CREATE INDEX ix_repo_canonical ON ingestion_service.document_nodes (repo_id, canonical_id)")
+    op.execute(
+        "CREATE INDEX ix_repo_canonical "
+        "ON ingestion_service.document_nodes (repo_id, canonical_id)"
+    )
 
     # Optional: Index on ingestion_id if we plan to query by this frequently
-    op.execute("CREATE INDEX ix_document_nodes_ingestion_id ON ingestion_service.document_nodes (ingestion_id)")
+    op.execute(
+        "CREATE INDEX ix_document_nodes_ingestion_id "
+        "ON ingestion_service.document_nodes (ingestion_id)"
+    )
+
 
 def downgrade() -> None:
     """Drop tables in reverse order to respect foreign key constraints."""

--- a/migrations/versions/20260201_add_document_relationships_table.py
+++ b/migrations/versions/20260201_add_document_relationships_table.py
@@ -18,12 +18,17 @@ def upgrade() -> None:
     op.execute("""
     CREATE TABLE IF NOT EXISTS ingestion_service.document_relationships (
         id SERIAL PRIMARY KEY,
-        from_document_id UUID NOT NULL REFERENCES ingestion_service.document_nodes(document_id) ON DELETE CASCADE,
-        to_document_id UUID NOT NULL REFERENCES ingestion_service.document_nodes(document_id) ON DELETE CASCADE,
+        from_document_id UUID NOT NULL
+            REFERENCES ingestion_service.document_nodes(document_id)
+            ON DELETE CASCADE,
+        to_document_id UUID NOT NULL
+            REFERENCES ingestion_service.document_nodes(document_id)
+            ON DELETE CASCADE,
         relation_type TEXT NOT NULL,
         relationship_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
         created_at TIMESTAMPTZ DEFAULT now(),
-        CONSTRAINT uq_document_relationship UNIQUE (from_document_id, to_document_id, relation_type)
+        CONSTRAINT uq_document_relationship
+            UNIQUE (from_document_id, to_document_id, relation_type)
     )
     """)
 

--- a/migrations/versions/20260301_update_vector_dimensions_1024.py
+++ b/migrations/versions/20260301_update_vector_dimensions_1024.py
@@ -14,7 +14,9 @@ def upgrade() -> None:
     # Drop existing vector indexes before altering column types
     op.execute("DROP INDEX IF EXISTS ingestion_service.vectors_vector_idx")
     op.execute("DROP INDEX IF EXISTS ingestion_service.vector_chunks_vector_idx")
-    op.execute("DROP INDEX IF EXISTS ingestion_service.document_nodes_summary_embedding_idx")
+    op.execute(
+        "DROP INDEX IF EXISTS ingestion_service.document_nodes_summary_embedding_idx"
+    )
 
     # Alter vector columns to 1024 dimensions (mxbai-embed-large)
     op.execute("""

--- a/rag_orchestrator/src/core/service.py
+++ b/rag_orchestrator/src/core/service.py
@@ -21,7 +21,9 @@ from rag_orchestrator.src.retrieval.agent_adapter import (
 )
 from rag_orchestrator.src.retrieval.types import RetrievedChunk
 
-from rag_orchestrator.src.retrieval.codebase_utils import extract_canonical_ids_from_chunks
+from rag_orchestrator.src.retrieval.codebase_utils import (
+    extract_canonical_ids_from_chunks,
+)
 from rag_orchestrator.src.retrieval.traversal_selector import (
     select_traversal_strategies,
     execute_traversals_from_seeds,
@@ -264,7 +266,9 @@ async def hybrid_retrieve(
         )
 
     seed_canonical_ids = extract_canonical_ids_from_chunks(seed_chunks)
-    logger.info(f"📊 {len(seed_chunks)} chunks → {len(seed_canonical_ids)} canonical_ids")
+    logger.info(
+        f"📊 {len(seed_chunks)} chunks → {len(seed_canonical_ids)} canonical_ids"
+    )
 
     expanded_ranked = _rank_expanded_canonical_ids(query, repo_id, seed_canonical_ids)
     expanded_canonical_ids = set(expanded_ranked)

--- a/rag_orchestrator/src/retrieval/agent_adapter.py
+++ b/rag_orchestrator/src/retrieval/agent_adapter.py
@@ -43,12 +43,17 @@ def prepare_chunks_for_agent(
     max_chunks_per_doc: int = 5,
     max_total_chunks: int = 50,
     max_tokens: Optional[int] = None,  # optional token budget
-    chunk_token_count: Optional[Callable[[RetrievedChunk], int]] = None,  # token counting func
-    filter_chunk: Optional[Callable[[RetrievedChunk], bool]] = None,  # optional chunk filter
+    chunk_token_count: Optional[
+        Callable[[RetrievedChunk], int]
+    ] = None,  # token counting func
+    filter_chunk: Optional[
+        Callable[[RetrievedChunk], bool]
+    ] = None,  # optional chunk filter
     debug: bool = False,
 ) -> List[Dict[str, object]]:
     """
-    Convert RetrievedContext into a deterministic list of chunk dicts for agent consumption,
+    Convert RetrievedContext into a deterministic list of chunk
+    dicts for agent consumption,
     preserving provenance, enforcing optional token budget, scoring, and filtering.
 
     Args:
@@ -78,7 +83,8 @@ def prepare_chunks_for_agent(
 
     logger.info(
         f"Preparing agent-ready chunks for {len(document_order)} documents "
-        f"(max_chunks_per_doc={max_chunks_per_doc}, max_total_chunks={max_total_chunks}, max_tokens={max_tokens})"
+        f"(max_chunks_per_doc={max_chunks_per_doc}, "
+        f"max_total_chunks={max_total_chunks}, max_tokens={max_tokens})"
     )
 
     final_chunks: List[Dict[str, object]] = []
@@ -111,7 +117,8 @@ def prepare_chunks_for_agent(
             chunk_tokens = chunk_token_count(c) if chunk_token_count else 0
             if max_tokens is not None and total_tokens + chunk_tokens > max_tokens:
                 logger.debug(
-                    f"Reached max_tokens={max_tokens} after {total_tokens} tokens, stopping"
+                    f"Reached max_tokens={max_tokens} "
+                    f"after {total_tokens} tokens, stopping"
                 )
                 return final_chunks  # stop adding more chunks
 
@@ -127,5 +134,8 @@ def prepare_chunks_for_agent(
             f"(total so far={len(final_chunks)}, tokens={total_tokens})"
         )
 
-    logger.info(f"Prepared {len(final_chunks)} chunks for agent consumption with provenance, total tokens={total_tokens}")
+    logger.info(
+        f"Prepared {len(final_chunks)} chunks for agent consumption "
+        f"with provenance, total tokens={total_tokens}"
+    )
     return final_chunks

--- a/rag_orchestrator/src/retrieval/codebase_queries.py
+++ b/rag_orchestrator/src/retrieval/codebase_queries.py
@@ -19,8 +19,12 @@ class Node:
         self.canonical_id = canonical_id
         self.file_path = file_path
         self.lineno = lineno
-        self.out_edges: Dict[str, Set['Node']] = defaultdict(set)  # relation_type -> set of target nodes
-        self.in_edges: Dict[str, Set['Node']] = defaultdict(set)   # relation_type -> set of source nodes
+        self.out_edges: Dict[str, Set["Node"]] = defaultdict(
+            set
+        )  # relation_type -> set of target nodes
+        self.in_edges: Dict[str, Set["Node"]] = defaultdict(
+            set
+        )  # relation_type -> set of source nodes
 
     def __repr__(self):
         return f"Node({self.canonical_id})"
@@ -79,7 +83,9 @@ def bfs_traversal(
             continue
 
         # Choose edges based on direction
-        edges = current_node.out_edges if direction == "forward" else current_node.in_edges
+        edges = (
+            current_node.out_edges if direction == "forward" else current_node.in_edges
+        )
 
         for rel, neighbors in edges.items():
             if relation_types and rel not in relation_types:
@@ -96,55 +102,113 @@ def bfs_traversal(
 
 def traverse_calls(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
     """Traverse CALL edges forward (what does this node call?)."""
-    return bfs_traversal(graph, start_cid, relation_types={"CALL"}, direction="forward", max_depth=depth)
+    return bfs_traversal(
+        graph, start_cid, relation_types={"CALL"}, direction="forward", max_depth=depth
+    )
 
 
-def traverse_defines(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+def traverse_defines(
+    graph: CodebaseGraph, start_cid: str, depth: int = 3
+) -> List[Node]:
     """Traverse DEFINES edges forward (what does this node define?)."""
-    return bfs_traversal(graph, start_cid, relation_types={"DEFINES"}, direction="forward", max_depth=depth)
+    return bfs_traversal(
+        graph,
+        start_cid,
+        relation_types={"DEFINES"},
+        direction="forward",
+        max_depth=depth,
+    )
 
 
-def traverse_incoming_calls(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+def traverse_incoming_calls(
+    graph: CodebaseGraph, start_cid: str, depth: int = 3
+) -> List[Node]:
     """Traverse CALL edges in reverse (what calls this node?)."""
-    return bfs_traversal(graph, start_cid, relation_types={"CALL"}, direction="reverse", max_depth=depth)
+    return bfs_traversal(
+        graph, start_cid, relation_types={"CALL"}, direction="reverse", max_depth=depth
+    )
 
 
-def traverse_incoming_imports(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+def traverse_incoming_imports(
+    graph: CodebaseGraph, start_cid: str, depth: int = 3
+) -> List[Node]:
     """Traverse IMPORTS edges in reverse (what imports this node?).
 
     F-02: ingestion now materializes MODULE --IMPORTS--> MODULE edges
     (relation_type "IMPORTS"); the old "IMPORT" type never existed as an
     edge, so this traversal used to return nothing.
     """
-    return bfs_traversal(graph, start_cid, relation_types={"IMPORTS"}, direction="reverse", max_depth=depth)
+    return bfs_traversal(
+        graph,
+        start_cid,
+        relation_types={"IMPORTS"},
+        direction="reverse",
+        max_depth=depth,
+    )
 
 
 # WP-G6: traversals over the WP-G5 inheritance edges.
 
-def traverse_superclasses(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+def traverse_superclasses(
+    graph: CodebaseGraph, start_cid: str, depth: int = 3
+) -> List[Node]:
     """Traverse INHERITS edges forward (what does this class inherit from?)."""
-    return bfs_traversal(graph, start_cid, relation_types={"INHERITS"}, direction="forward", max_depth=depth)
+    return bfs_traversal(
+        graph,
+        start_cid,
+        relation_types={"INHERITS"},
+        direction="forward",
+        max_depth=depth,
+    )
 
 
-def traverse_subclasses(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+def traverse_subclasses(
+    graph: CodebaseGraph, start_cid: str, depth: int = 3
+) -> List[Node]:
     """Traverse INHERITS edges in reverse (what subclasses this class?)."""
-    return bfs_traversal(graph, start_cid, relation_types={"INHERITS"}, direction="reverse", max_depth=depth)
+    return bfs_traversal(
+        graph,
+        start_cid,
+        relation_types={"INHERITS"},
+        direction="reverse",
+        max_depth=depth,
+    )
 
 
-def traverse_overrides(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+def traverse_overrides(
+    graph: CodebaseGraph, start_cid: str, depth: int = 3
+) -> List[Node]:
     """Traverse OVERRIDES edges forward (which base method does this override?)."""
-    return bfs_traversal(graph, start_cid, relation_types={"OVERRIDES"}, direction="forward", max_depth=depth)
+    return bfs_traversal(
+        graph,
+        start_cid,
+        relation_types={"OVERRIDES"},
+        direction="forward",
+        max_depth=depth,
+    )
 
 
-def traverse_overridden_by(graph: CodebaseGraph, start_cid: str, depth: int = 3) -> List[Node]:
+def traverse_overridden_by(
+    graph: CodebaseGraph, start_cid: str, depth: int = 3
+) -> List[Node]:
     """Traverse OVERRIDES edges in reverse (which methods override this one?)."""
-    return bfs_traversal(graph, start_cid, relation_types={"OVERRIDES"}, direction="reverse", max_depth=depth)
+    return bfs_traversal(
+        graph,
+        start_cid,
+        relation_types={"OVERRIDES"},
+        direction="reverse",
+        max_depth=depth,
+    )
+
 
 # --- API Calls ---
 
-def get_nodes_by_canonical_ids_from_api(repo_id: str, canonical_ids: List[str]) -> List[Dict]:
+def get_nodes_by_canonical_ids_from_api(
+    repo_id: str, canonical_ids: List[str]
+) -> List[Dict]:
     """
-    Fetch nodes by canonical_ids from the ingestion_service API (instead of directly querying DB).
+    Fetch nodes by canonical_ids from the ingestion_service API
+    (instead of directly querying DB).
     """
     #url = f"http://ingestion_service/v1/graph/repos/{repo_id}/nodes"
     url = f"{ingestion_service_url}/v1/graph/repos/{repo_id}/nodes"
@@ -154,7 +218,9 @@ def get_nodes_by_canonical_ids_from_api(repo_id: str, canonical_ids: List[str]) 
     if response.status_code == 200:
         return response.json().get('nodes', [])
     else:
-        raise Exception(f"Error fetching nodes: {response.status_code} - {response.text}")
+        raise Exception(
+            f"Error fetching nodes: {response.status_code} - {response.text}"
+        )
 
 
 def get_full_graph_from_api(repo_id: str) -> Dict:
@@ -169,7 +235,9 @@ def get_full_graph_from_api(repo_id: str) -> Dict:
     if response.status_code == 200:
         return response.json()  # returns both nodes and edges
     else:
-        raise Exception(f"Error fetching full graph: {response.status_code} - {response.text}")
+        raise Exception(
+            f"Error fetching full graph: {response.status_code} - {response.text}"
+        )
 
 
 # --- Graph Loading ---

--- a/rag_orchestrator/src/retrieval/codebase_utils.py
+++ b/rag_orchestrator/src/retrieval/codebase_utils.py
@@ -29,7 +29,9 @@ def extract_canonical_ids_from_chunks(chunks: List) -> Set[str]:
         )
         if cid:
             canonical_ids.add(cid)
-    logger.debug(f"Extracted {len(canonical_ids)} canonical_ids from {len(chunks)} chunks")
+    logger.debug(
+        f"Extracted {len(canonical_ids)} canonical_ids from {len(chunks)} chunks"
+    )
     return canonical_ids
 
 
@@ -45,11 +47,18 @@ def canonical_ids_to_document_ids(
     url = f"{ingestion_service_url}/v1/graph/repos/{repo_id}/nodes"
     response = requests.get(url, params={"canonical_ids": ",".join(canonical_ids)})
     if response.status_code == 200:
-        document_ids = {node['document_id'] for node in response.json().get("nodes", [])}
-        logger.debug(f"Resolved {len(canonical_ids)} canonical_ids → {len(document_ids)} document_ids")
+        document_ids = {
+            node["document_id"] for node in response.json().get("nodes", [])
+        }
+        logger.debug(
+            f"Resolved {len(canonical_ids)} canonical_ids → "
+            f"{len(document_ids)} document_ids"
+        )
         return document_ids
     else:
-        logger.error(f"Error resolving canonical_ids: {response.status_code} - {response.text}")
+        logger.error(
+            f"Error resolving canonical_ids: {response.status_code} - {response.text}"
+        )
         return set()
 
 

--- a/rag_orchestrator/src/retrieval/execute_plan.py
+++ b/rag_orchestrator/src/retrieval/execute_plan.py
@@ -40,7 +40,10 @@ def execute_retrieval_plan(
 
     total_seed = len(plan.seed_document_ids)
     total_expanded = len(plan.expanded_document_ids)
-    logger.info(f"Executing RetrievalPlan: {total_seed} seed docs, {total_expanded} expanded docs")
+    logger.info(
+        f"Executing RetrievalPlan: {total_seed} seed docs, "
+        f"{total_expanded} expanded docs"
+    )
 
     # 1️⃣ Compute allowed document IDs (hard boundary)
     allowed_document_ids: List[str] = _ordered_unique(
@@ -65,7 +68,8 @@ def execute_retrieval_plan(
         for chunk in chunks:
             if chunk.document_id != document_id:
                 raise ValueError(
-                    f"Retrieved chunk from document {chunk.document_id}, expected {document_id}"
+                    f"Retrieved chunk from document "
+                    f"{chunk.document_id}, expected {document_id}"
                 )
 
         chunks_by_document[document_id] = chunks
@@ -73,11 +77,17 @@ def execute_retrieval_plan(
         # 4️⃣ Detailed chunk logging
         for c in chunks:
             preview = (c.text[:50] + "...") if len(c.text) > 50 else c.text
-            logger.debug(f"Doc={document_id} | ChunkID={c.chunk_id} | Score={c.score:.4f} | TextPreview='{preview}'")
+            logger.debug(
+                f"Doc={document_id} | ChunkID={c.chunk_id} | "
+                f"Score={c.score:.4f} | TextPreview='{preview}'"
+            )
 
         logger.debug(f"Retrieved {len(chunks)} chunks for document_id={document_id}")
 
-    logger.info(f"Finished executing RetrievalPlan; total documents retrieved: {len(chunks_by_document)}")
+    logger.info(
+        f"Finished executing RetrievalPlan; "
+        f"total documents retrieved: {len(chunks_by_document)}"
+    )
     return RetrievedContext(chunks_by_document=chunks_by_document)
 
 

--- a/rag_orchestrator/src/retrieval/http_utils.py
+++ b/rag_orchestrator/src/retrieval/http_utils.py
@@ -11,7 +11,10 @@ def extract_canonical_ids_from_chunks(chunks: List[RetrievedChunk]) -> Set[str]:
     canonical_ids = {
         canonical_id
         for chunk in chunks
-        if chunk.metadata and (canonical_id := chunk.metadata.get("canonical_id")) is not None
+        if chunk.metadata
+        and (canonical_id := chunk.metadata.get("canonical_id")) is not None
     }
-    logger.debug(f"Extracted {len(canonical_ids)} canonical_ids from {len(chunks)} chunks")
+    logger.debug(
+        f"Extracted {len(canonical_ids)} canonical_ids from {len(chunks)} chunks"
+    )
     return canonical_ids

--- a/rag_orchestrator/src/retrieval/summary_adapter.py
+++ b/rag_orchestrator/src/retrieval/summary_adapter.py
@@ -23,14 +23,18 @@ def fetch_summaries(document_ids: List[str]) -> Dict[str, str]:
 
     for doc_id in document_ids:
         try:
-            resp = requests.get(f"{INGESTION_API_BASE_URL}/v1/summary/{doc_id}", timeout=300)
+            resp = requests.get(
+                f"{INGESTION_API_BASE_URL}/v1/summary/{doc_id}", timeout=300
+            )
             if resp.status_code == 200:
                 data = resp.json()
                 summary_text = data.get("summary")
                 if summary_text:
                     summaries[doc_id] = summary_text
             else:
-                logger.debug(f"No summary for doc_id={doc_id} (status={resp.status_code})")
+                logger.debug(
+                    f"No summary for doc_id={doc_id} (status={resp.status_code})"
+                )
         except Exception as exc:
             logger.warning(f"Error fetching summary for doc_id={doc_id}: {exc}")
 

--- a/rag_orchestrator/src/retrieval/traversal_planner.py
+++ b/rag_orchestrator/src/retrieval/traversal_planner.py
@@ -16,7 +16,9 @@ class TraversalConstraints:
 def expand_retrieval_plan(
     *,
     plan: RetrievalPlan,
-    list_outgoing_relationships: Callable[[str], List[Dict]],  # document_id -> List[dict]
+    list_outgoing_relationships: Callable[
+        [str], List[Dict]
+    ],  # document_id -> List[dict]
     constraints: TraversalConstraints,
 ) -> RetrievalPlan:
     """
@@ -50,7 +52,10 @@ def expand_retrieval_plan(
             relation_type = rel.get('relation_type')
 
             # Skip disallowed types
-            if constraints.allowed_relation_types and relation_type not in constraints.allowed_relation_types:
+            if (
+                constraints.allowed_relation_types
+                and relation_type not in constraints.allowed_relation_types
+            ):
                 continue
 
             if target_id not in visited:

--- a/rag_orchestrator/src/retrieval/traversal_selector.py
+++ b/rag_orchestrator/src/retrieval/traversal_selector.py
@@ -141,7 +141,9 @@ def select_traversal_strategies(
         logger.debug("Selected: default (defines + calls)")
         strategies = [factory() for factory in _DEFAULT_STRATEGIES]
 
-    logger.info(f"Selected {len(strategies)} traversal strategies for query: '{query[:50]}...'")
+    logger.info(
+        f"Selected {len(strategies)} traversal strategies for query: '{query[:50]}...'"
+    )
     return strategies
 
 def execute_traversals(
@@ -158,7 +160,9 @@ def execute_traversals(
         try:
             nodes = strategy(graph, start_canonical_id)
             all_expanded_nodes.extend(nodes)
-            logger.debug(f"Strategy returned {len(nodes)} nodes from {start_canonical_id}")
+            logger.debug(
+                f"Strategy returned {len(nodes)} nodes from {start_canonical_id}"
+            )
         except Exception as e:
             logger.warning(f"Traversal strategy failed: {e}")
             continue

--- a/rag_orchestrator/tests/test_build_sources.py
+++ b/rag_orchestrator/tests/test_build_sources.py
@@ -16,7 +16,12 @@ def chunk(document_id, canonical_id=None, relative_path=None):
         metadata["canonical_id"] = canonical_id
     if relative_path:
         metadata["relative_path"] = relative_path
-    return {"text": "x", "document_id": document_id, "chunk_id": "c", "metadata": metadata}
+    return {
+        "text": "x",
+        "document_id": document_id,
+        "chunk_id": "c",
+        "metadata": metadata,
+    }
 
 
 def test_canonical_id_preferred_over_path_and_uuid():

--- a/rag_orchestrator/tests/test_expansion_caps.py
+++ b/rag_orchestrator/tests/test_expansion_caps.py
@@ -106,7 +106,9 @@ def _run_hybrid(monkeypatch, backend):
         return real_async_client(*args, **kwargs)
 
     monkeypatch.setattr(httpx, "AsyncClient", patched_client)
-    monkeypatch.setattr(codebase_utils, "get_cached_graph", lambda repo_id: _build_graph())
+    monkeypatch.setattr(
+        codebase_utils, "get_cached_graph", lambda repo_id: _build_graph()
+    )
 
     return asyncio.run(
         hybrid_retrieve(

--- a/rag_orchestrator/tests/test_traversal_selector_routing.py
+++ b/rag_orchestrator/tests/test_traversal_selector_routing.py
@@ -56,7 +56,10 @@ CASES = [
     ("superclasses of HttpVectorStore", [traverse_superclasses]),
     # WP-G6: override intent runs both directions
     ("what overrides speak", [traverse_overrides, traverse_overridden_by]),
-    ("which methods are overridden in Dog", [traverse_overrides, traverse_overridden_by]),
+    (
+        "which methods are overridden in Dog",
+        [traverse_overrides, traverse_overridden_by],
+    ),
     # substring words no longer hijack routing → default (defines+calls)
     ("explain ingest_repo", [traverse_defines, traverse_calls]),
     ("how does print_summary work", [traverse_defines, traverse_calls]),

--- a/ruff.toml
+++ b/ruff.toml
@@ -9,6 +9,8 @@ exclude = [
 ]
 [lint]
 select = ["E", "F", "W", "C"]
-# E501: ~150 pre-existing long lines; enforcing now would mean a repo-wide
-# cosmetic reformat. Temporarily ignored — re-enable via issue #28.
-ignore = ["E501"]
+
+[lint.per-file-ignores]
+# Long-line prose fixture: the chunker input is a single continued string
+# literal whose line lengths are part of the test data (issue #28).
+"ingestion_service/tests/core/chunkers/test_text_chunker.py" = ["E501"]

--- a/shared/models/document_relationship.py
+++ b/shared/models/document_relationship.py
@@ -34,7 +34,9 @@ class DocumentRelationship(Base):
 
     __tablename__ = "document_relationships"
     __table_args__ = {"schema": "ingestion_service"}
-    logger.debug("DocumentRelationship Represents a relationship between two DocumentNodes.")
+    logger.debug(
+        "DocumentRelationship Represents a relationship between two DocumentNodes."
+    )
 
     # -----------------------------
     # Primary Key

--- a/shared/models/vector_chunk.py
+++ b/shared/models/vector_chunk.py
@@ -25,7 +25,8 @@ class VectorChunk(Base):
         ingestion_id: The ingestion request that produced this chunk.
         chunk_id: Unique identifier for the chunk within the ingestion.
         chunk_index: Sequential index of the chunk.
-        chunk_strategy: Strategy used to create the chunk (e.g., 'sentence', 'paragraph').
+        chunk_strategy: Strategy used to create the chunk
+            (e.g., 'sentence', 'paragraph').
         chunk_text: The text content of the chunk.
         source_metadata: JSON metadata about the source.
         provider: The embedding provider or source system.
@@ -49,7 +50,9 @@ class VectorChunk(Base):
     chunk_index: int = Column(Integer, nullable=False)
     chunk_strategy: str = Column(String, nullable=False)
     chunk_text: str = Column(String, nullable=False)
-    source_metadata: dict = Column(JSON, nullable=False, default=dict)  # fixed mutable default
+    source_metadata: dict = Column(
+        JSON, nullable=False, default=dict
+    )  # fixed mutable default
     provider: str = Column(String, nullable=False, default="ollama")
 
     # -----------------------------

--- a/vector_store_service/src/api/v1/vectors.py
+++ b/vector_store_service/src/api/v1/vectors.py
@@ -131,7 +131,8 @@ async def search_by_document(
                     "chunk_id": r.metadata.chunk_id,
                     "text": r.metadata.chunk_text,
                     "document_id": r.metadata.document_id,
-                    "score": 1.0,   # no similarity computed for doc fetch, treat as full match
+                    # no similarity computed for doc fetch; treat as full match
+                    "score": 1.0,
                     "metadata": {
                         "ingestion_id": r.metadata.ingestion_id,
                         "chunk_index": r.metadata.chunk_index,

--- a/vector_store_service/src/core/vectorstore/pgvector_store.py
+++ b/vector_store_service/src/core/vectorstore/pgvector_store.py
@@ -128,7 +128,8 @@ class PgVectorStore(VectorStore):
             where_clause = sql.SQL(" AND ").join(conditions)
             search_sql = sql.SQL("""
                 WITH query AS (SELECT {qvec}::vector AS qvec)
-                SELECT vc.vector, vc.ingestion_id, vc.chunk_id, vc.chunk_index, vc.chunk_strategy,
+                SELECT vc.vector, vc.ingestion_id, vc.chunk_id,
+                       vc.chunk_index, vc.chunk_strategy,
                        vc.chunk_text, vc.source_metadata, vc.provider, vc.document_id,
                        1 - (vc.vector <=> query.qvec) AS score
                 FROM {schema}.vector_chunks vc, query
@@ -146,7 +147,8 @@ class PgVectorStore(VectorStore):
         else:
             search_sql = sql.SQL("""
                 WITH query AS (SELECT {qvec}::vector AS qvec)
-                SELECT vc.vector, vc.ingestion_id, vc.chunk_id, vc.chunk_index, vc.chunk_strategy,
+                SELECT vc.vector, vc.ingestion_id, vc.chunk_id,
+                       vc.chunk_index, vc.chunk_strategy,
                        vc.chunk_text, vc.source_metadata, vc.provider, vc.document_id,
                        1 - (vc.vector <=> query.qvec) AS score
                 FROM {schema}.vector_chunks vc, query
@@ -201,7 +203,9 @@ class PgVectorStore(VectorStore):
                 with conn.cursor() as cur:
                     cur.execute(delete_sql, (ingestion_id,))
 
-    def get_chunks_by_document_id(self, document_id: str, k: int = 3) -> List[VectorRecord]:
+    def get_chunks_by_document_id(
+        self, document_id: str, k: int = 3
+    ) -> List[VectorRecord]:
         """Fetch chunks for a specific document_id — no vector similarity needed."""
         search_sql = sql.SQL("""
             SELECT vector, ingestion_id, chunk_id, chunk_index, chunk_strategy,


### PR DESCRIPTION
Standalone reformat PR, deliberately isolated so the noisy diff never mixes with feature work. No behavior changes.

- E501 removed from the `ruff.toml` ignore; repo-wide ruff clean with it enforced.
- 91 of 144 lines fixed via `ruff format --range` scoped to each offending line — statement-level only, no repo-wide style churn.
- 53 formatter-resistant lines wrapped by hand: implicit string concat for f-strings, docstring re-flow, whitespace-only SQL line breaks in migrations (identical schema), one variable extraction where an f-string expression couldn't be split.
- `test_text_chunker.py` gets a per-file E501 ignore — its chunker input is a continued prose string literal whose line lengths are test data.

All suites green: ingestion 94, orchestrator 67, vector_store 7, llm 28.

Closes #28