### PR TITLE
WP-S4B: typed repo_id/doc_type filter columns on vector_chunks

### DIFF
--- a/migrations/versions/20260719_typed_filter_columns.py
+++ b/migrations/versions/20260719_typed_filter_columns.py
@@ -1,0 +1,73 @@
+"""Promote repo_id/doc_type to typed columns on vector_chunks (WP-S4B)
+
+Issue #30 made repo_id filtering correctness-critical on every query;
+keeping it in JSONB is both a scan cost and — because pgvector's HNSW
+post-filters — a recall risk as the table grows. This migration:
+
+- adds repo_id TEXT and doc_type TEXT columns,
+- backfills them from source_metadata (historical rows included),
+- indexes them (btree; composite repo_id+doc_type for the hybrid
+  query's exact shape),
+- drops the two JSONB expression indexes they replace.
+
+The columns are denormalized copies of source_metadata keys; the write
+path populates both from the same values, so they cannot drift for new
+rows.
+
+Revision ID: 20260719_typed_cols
+Revises: 20260718_vc_idx
+Create Date: 2026-07-19
+"""
+
+from alembic import op
+
+revision = "20260719_typed_cols"
+down_revision = "20260718_vc_idx"
+branch_labels = None
+depends_on = None
+
+TABLE = "ingestion_service.vector_chunks"
+
+
+def upgrade() -> None:
+    op.execute(f"ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS repo_id TEXT")
+    op.execute(f"ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS doc_type TEXT")
+
+    op.execute(
+        f"UPDATE {TABLE} SET "
+        "repo_id = source_metadata->>'repo_id', "
+        "doc_type = source_metadata->>'doc_type' "
+        "WHERE repo_id IS NULL AND doc_type IS NULL"
+    )
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vector_chunks_repo_doc "
+        f"ON {TABLE} (repo_id, doc_type)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vector_chunks_doc_type_col "
+        f"ON {TABLE} (doc_type)"
+    )
+
+    # superseded JSONB expression indexes (20260718_vc_idx)
+    op.execute("DROP INDEX IF EXISTS ingestion_service.ix_vector_chunks_doc_type")
+    op.execute("DROP INDEX IF EXISTS ingestion_service.ix_vector_chunks_repo_id")
+
+    op.execute(f"ANALYZE {TABLE}")
+
+
+def downgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vector_chunks_doc_type "
+        f"ON {TABLE} ((source_metadata->>'doc_type'))"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vector_chunks_repo_id "
+        f"ON {TABLE} ((source_metadata->>'repo_id'))"
+    )
+    op.execute("DROP INDEX IF EXISTS ingestion_service.ix_vector_chunks_repo_doc")
+    op.execute(
+        "DROP INDEX IF EXISTS ingestion_service.ix_vector_chunks_doc_type_col"
+    )
+    op.execute(f"ALTER TABLE {TABLE} DROP COLUMN IF EXISTS repo_id")
+    op.execute(f"ALTER TABLE {TABLE} DROP COLUMN IF EXISTS doc_type")

--- a/vector_store_service/src/core/vectorstore/pgvector_store.py
+++ b/vector_store_service/src/core/vectorstore/pgvector_store.py
@@ -19,6 +19,11 @@ class PgVectorStore(VectorStore):
     # better recall, slower query. 100 is comfortable for k <= 50.
     HNSW_EF_SEARCH = 100
 
+    # WP-S4B: filter keys promoted from JSONB to real indexed columns.
+    # The write path copies them out of source_metadata, so filtering on
+    # the column and on the JSONB key are equivalent for every row.
+    TYPED_FILTER_COLUMNS = frozenset({"repo_id", "doc_type"})
+
     def __init__(self, dsn: str, dimension: int, provider: str = "mock") -> None:
         self._dsn = dsn
         self._dimension = dimension
@@ -44,24 +49,83 @@ class PgVectorStore(VectorStore):
         chunks_sql = sql.SQL("""
             INSERT INTO {schema}.vector_chunks
             (vector, ingestion_id, chunk_id, chunk_index, chunk_strategy,
-             chunk_text, source_metadata, provider, document_id)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+             chunk_text, source_metadata, provider, document_id,
+             repo_id, doc_type)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """).format(schema=sql.Identifier(self.SCHEMA))
 
         with psycopg.connect(self._dsn) as conn:
             with conn.cursor() as cur:
                 for record in records:
+                    source_metadata = record.metadata.source_metadata or {}
                     cur.execute(chunks_sql, (
                         record.vector, record.metadata.ingestion_id,
                         record.metadata.chunk_id, record.metadata.chunk_index,
                         record.metadata.chunk_strategy, record.metadata.chunk_text,
-                        Jsonb(record.metadata.source_metadata or {}),
+                        Jsonb(source_metadata),
                         record.metadata.provider or self._provider,
                         record.metadata.document_id or None,
+                        # WP-S4B: typed copies of the filter-critical keys
+                        source_metadata.get("repo_id"),
+                        source_metadata.get("doc_type"),
                     ))
         logging.info(
             "PgVectorStore.add: %d records written to vector_chunks", len(records)
         )
+
+    @classmethod
+    def _filter_target(cls, key: str) -> sql.Composable:
+        """SQL expression a filter key applies to: the typed column for
+        promoted keys (WP-S4B), else the JSONB lookup."""
+        if key in cls.TYPED_FILTER_COLUMNS:
+            return sql.SQL("vc.{col}").format(col=sql.Identifier(key))
+        return sql.SQL("vc.source_metadata->>{key}").format(
+            key=sql.Literal(key)
+        )
+
+    @classmethod
+    def _build_filter_conditions(
+        cls, metadata_filter: Dict[str, Any]
+    ) -> tuple[List[sql.Composable], List[Any]]:
+        conditions: List[sql.Composable] = []
+        filter_values: List[Any] = []
+
+        for key, value in metadata_filter.items():
+            target = cls._filter_target(key)
+
+            if isinstance(value, dict):
+                operator = list(value.keys())[0]
+                operand = list(value.values())[0]
+
+                if operator == "ne":
+                    conditions.append(
+                        sql.SQL(
+                            "({target} IS NULL OR {target} != {val})"
+                        ).format(target=target, val=sql.Placeholder())
+                    )
+                    filter_values.append(operand)
+
+                elif operator == "in":
+                    placeholders = sql.SQL(", ").join(
+                        sql.Placeholder() for _ in operand
+                    )
+                    conditions.append(
+                        sql.SQL("{target} IN ({vals})").format(
+                            target=target, vals=placeholders
+                        )
+                    )
+                    filter_values.extend(operand)
+
+            else:
+                # Simple equality
+                conditions.append(
+                    sql.SQL("{target} = {val}").format(
+                        target=target, val=sql.Placeholder()
+                    )
+                )
+                filter_values.append(value)
+
+        return conditions, filter_values
 
     def similarity_search(
         self,
@@ -79,52 +143,14 @@ class PgVectorStore(VectorStore):
             {"source_type": "code"}              → equality
             {"source_type": {"ne": "code"}}      → not equal (also matches NULL)
             {"doc_type": {"in": ["file","pdf"]}} → IN list
+
+        repo_id / doc_type filter on their typed columns (WP-S4B); every
+        other key filters on the source_metadata JSONB as before.
         """
         if metadata_filter:
-            conditions = []
-            filter_values = []
-
-            for key, value in metadata_filter.items():
-                if isinstance(value, dict):
-                    operator = list(value.keys())[0]
-                    operand = list(value.values())[0]
-
-                    if operator == "ne":
-                        conditions.append(
-                            sql.SQL(
-                                "(source_metadata->>{key} IS NULL "
-                                "OR source_metadata->>{key} != {val})"
-                            ).format(
-                                key=sql.Literal(key),
-                                val=sql.Placeholder(),
-                            )
-                        )
-                        filter_values.append(operand)
-
-                    elif operator == "in":
-                        placeholders = sql.SQL(", ").join(
-                            sql.Placeholder() for _ in operand
-                        )
-                        conditions.append(
-                            sql.SQL(
-                                "source_metadata->>{key} IN ({vals})"
-                            ).format(
-                                key=sql.Literal(key),
-                                vals=placeholders,
-                            )
-                        )
-                        filter_values.extend(operand)
-
-                else:
-                    # Simple equality
-                    conditions.append(
-                        sql.SQL("source_metadata->>{key} = {val}").format(
-                            key=sql.Literal(key),
-                            val=sql.Placeholder(),
-                        )
-                    )
-                    filter_values.append(value)
-
+            conditions, filter_values = self._build_filter_conditions(
+                metadata_filter
+            )
             where_clause = sql.SQL(" AND ").join(conditions)
             search_sql = sql.SQL("""
                 WITH query AS (SELECT {qvec}::vector AS qvec)

--- a/vector_store_service/tests/core/vectorstore/test_ann_index_usage.py
+++ b/vector_store_service/tests/core/vectorstore/test_ann_index_usage.py
@@ -1,11 +1,13 @@
 # tests/core/vectorstore/test_ann_index_usage.py
 """
-F-10 (WP-S4): vector search must be index-backed, not a sequential scan.
+F-10 (WP-S4) + WP-S4B: vector search must be index-backed, not a
+sequential scan.
 
 Asserts via EXPLAIN against the docker-compose.test.yml Postgres
-(migration 20260718_vc_idx applied) that:
+(migrations 20260718_vc_idx + 20260719_typed_cols applied) that:
 - ANN ordering uses the HNSW index (ix_vector_chunks_hnsw);
-- doc_type / repo_id JSONB filters can use their expression indexes;
+- doc_type / repo_id filters use the typed-column indexes (WP-S4B
+  replaced the JSONB expression indexes);
 - document_id lookups use their btree index.
 
 The test dataset is tiny, so the planner would prefer a seq scan on
@@ -88,26 +90,50 @@ def test_similarity_search_uses_hnsw_index(store):
     assert "Seq Scan" not in plan, plan
 
 
-def test_doc_type_filter_uses_expression_index(store):
+def test_doc_type_filter_uses_typed_column_index(store):
     plan = _explain(
         """
         SELECT chunk_id FROM ingestion_service.vector_chunks
-        WHERE source_metadata->>'doc_type' = %s
+        WHERE doc_type = %s
         """,
         ("code",),
     )
-    assert "ix_vector_chunks_doc_type" in plan, plan
+    assert "ix_vector_chunks_doc_type_col" in plan, plan
 
 
-def test_repo_id_filter_uses_expression_index(store):
+def test_repo_filter_uses_typed_column_indexes(store):
+    """WP-S4B: the hybrid query's exact filter shape (repo_id + doc_type)
+    is served by typed-column indexes — the planner may pick the
+    composite or a single-column index depending on stats, but it must
+    not fall back to a seq scan or JSONB evaluation."""
     plan = _explain(
         """
         SELECT chunk_id FROM ingestion_service.vector_chunks
-        WHERE source_metadata->>'repo_id' = %s
+        WHERE repo_id = %s AND doc_type = %s
         """,
-        ("repo-1",),
+        ("repo-1", "code"),
     )
-    assert "ix_vector_chunks_repo_id" in plan, plan
+    assert (
+        "ix_vector_chunks_repo_doc" in plan
+        or "ix_vector_chunks_doc_type_col" in plan
+    ), plan
+    assert "Seq Scan" not in plan, plan
+    assert "source_metadata" not in plan, plan
+
+
+def test_typed_columns_backfilled_on_write(store):
+    """store.add() populates the typed columns from source_metadata."""
+    with psycopg.connect(_dsn()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*) FROM ingestion_service.vector_chunks
+                WHERE source_metadata->>'repo_id' IS NOT NULL
+                  AND (repo_id IS NULL
+                       OR repo_id != source_metadata->>'repo_id')
+                """
+            )
+            assert cur.fetchone()[0] == 0
 
 
 def test_document_id_lookup_uses_index(store):

--- a/vector_store_service/tests/core/vectorstore/test_typed_filter_columns.py
+++ b/vector_store_service/tests/core/vectorstore/test_typed_filter_columns.py
@@ -1,0 +1,62 @@
+# tests/core/vectorstore/test_typed_filter_columns.py
+"""
+WP-S4B: repo_id/doc_type filters target their typed columns; everything
+else stays on the source_metadata JSONB. Pure SQL-construction tests —
+no database needed.
+"""
+import pytest
+
+from src.core.vectorstore.pgvector_store import PgVectorStore
+
+pytestmark = pytest.mark.unit
+
+
+def render(metadata_filter):
+    conditions, values = PgVectorStore._build_filter_conditions(metadata_filter)
+    return [c.as_string(None) for c in conditions], values
+
+
+def test_repo_id_equality_uses_typed_column():
+    conditions, values = render({"repo_id": "repo-x"})
+    assert conditions == ['vc."repo_id" = %s']
+    assert values == ["repo-x"]
+
+
+def test_doc_type_equality_uses_typed_column():
+    conditions, values = render({"doc_type": "code"})
+    assert conditions == ['vc."doc_type" = %s']
+    assert values == ["code"]
+
+
+def test_other_keys_stay_on_jsonb():
+    conditions, values = render({"canonical_id": "a.py#f"})
+    assert conditions == ["vc.source_metadata->>'canonical_id' = %s"]
+    assert values == ["a.py#f"]
+
+
+def test_hybrid_query_filter_shape():
+    """The exact filter the orchestrator sends (issue #30 Part 1)."""
+    conditions, values = render({"doc_type": "code", "repo_id": "repo-x"})
+    assert conditions == ['vc."doc_type" = %s', 'vc."repo_id" = %s']
+    assert values == ["code", "repo-x"]
+
+
+def test_ne_operator_on_typed_column_matches_null():
+    conditions, values = render({"doc_type": {"ne": "code"}})
+    assert conditions == ['(vc."doc_type" IS NULL OR vc."doc_type" != %s)']
+    assert values == ["code"]
+
+
+def test_ne_operator_on_jsonb_key():
+    conditions, values = render({"source_type": {"ne": "code"}})
+    assert conditions == [
+        "(vc.source_metadata->>'source_type' IS NULL "
+        "OR vc.source_metadata->>'source_type' != %s)"
+    ]
+    assert values == ["code"]
+
+
+def test_in_operator_on_typed_column():
+    conditions, values = render({"doc_type": {"in": ["file", "pdf"]}})
+    assert conditions == ['vc."doc_type" IN (%s, %s)']
+    assert values == ["file", "pdf"]


### PR DESCRIPTION
The WP-S4 follow-up from the Phase 1 exit report, scheduled before any serious scale validation. Issue #30 made `repo_id` filtering correctness-critical on every hybrid query; JSONB filtering was both a scan cost and — because pgvector's HNSW **post-filters** candidates — a recall risk for small repos in a large multi-repo table.

- **Migration `20260719_typed_cols`**: adds `repo_id`/`doc_type` TEXT columns, backfills from `source_metadata` (historical rows included), adds a composite `(repo_id, doc_type)` index for the hybrid query's exact shape plus a `doc_type` btree, drops the superseded JSONB expression indexes. Downgrade restores the prior state — roundtrip verified against the test DB.
- **Write path**: `add()` populates both columns from the same `source_metadata` values — no drift possible for new rows.
- **Filter path**: `repo_id`/`doc_type` now target their typed columns; all other keys stay on JSONB. `metadata_filter` API unchanged for callers.
- **Tests**: 7 new unit tests on SQL construction (typed vs JSONB targets, `ne`/`in`, the exact issue-30 filter shape); integration tests assert via EXPLAIN that filters use typed-column indexes with no seq scan and no `source_metadata` evaluation, and that writes backfill the columns.

Deliberately out of scope, still tracked: the 1M-row search load test (needs the columns in place first — that's this PR).

vector_store unit 14 ✅ · integration 6 ✅ (local test-compose DB, full migration chain) 