### PR TITLE
Fix RAG sources falling back to UUIDs (nested source_metadata)

### DIFF
--- a/rag_orchestrator/src/retrieval/agent_adapter.py
+++ b/rag_orchestrator/src/retrieval/agent_adapter.py
@@ -15,8 +15,12 @@ def build_sources(agent_chunks: List[Dict[str, object]]) -> List[str]:
 
     Prefers canonical_id from chunk metadata (`path` or
     `path#Class.method` per ADR-031), then relative_path, then the raw
-    document_id. Labels keep first-seen order, so with seeds ordered
-    before expanded documents the seed sources come first.
+    document_id. The vector store's search response nests the ingestion
+    metadata under `metadata.source_metadata` (vectors.py), so both the
+    flat and nested shapes are checked — same duality
+    extract_canonical_ids_from_chunks handles. Labels keep first-seen
+    order, so with seeds ordered before expanded documents the seed
+    sources come first.
     """
     sources: List[str] = []
     seen: set = set()
@@ -25,9 +29,15 @@ def build_sources(agent_chunks: List[Dict[str, object]]) -> List[str]:
         metadata: Dict[str, object] = (
             raw_metadata if isinstance(raw_metadata, dict) else {}
         )
+        raw_nested = metadata.get("source_metadata")
+        nested: Dict[str, object] = (
+            raw_nested if isinstance(raw_nested, dict) else {}
+        )
         label = (
             metadata.get("canonical_id")
+            or nested.get("canonical_id")
             or metadata.get("relative_path")
+            or nested.get("relative_path")
             or c.get("document_id")
         )
         if label and label not in seen:

--- a/rag_orchestrator/tests/test_build_sources.py
+++ b/rag_orchestrator/tests/test_build_sources.py
@@ -58,6 +58,37 @@ def test_seed_chunks_stay_ahead_of_expanded():
     assert build_sources(chunks) == ["seed.py#hit", "expanded.py#neighbor"]
 
 
+def test_nested_source_metadata_shape_from_vector_store():
+    """The real /v1/vectors/search response nests canonical_id under
+    metadata.source_metadata (caught by the live smoke test — the flat
+    shape below never occurs in production for repo chunks)."""
+    chunks = [{
+        "text": "x",
+        "document_id": "uuid-1",
+        "chunk_id": "c",
+        "metadata": {
+            "ingestion_id": "ing-1",
+            "chunk_index": 0,
+            "chunk_strategy": "sentence",
+            "provider": "ollama",
+            "source_metadata": {
+                "canonical_id": "dogs.py#Dog.speak",
+                "relative_path": "dogs.py",
+                "repo_id": "repo-x",
+            },
+        },
+    }]
+    assert build_sources(chunks) == ["dogs.py#Dog.speak"]
+
+
+def test_nested_relative_path_fallback():
+    chunks = [{
+        "document_id": "uuid-2",
+        "metadata": {"source_metadata": {"relative_path": "docs/readme.md"}},
+    }]
+    assert build_sources(chunks) == ["docs/readme.md"]
+
+
 def test_missing_metadata_dict_is_tolerated():
     assert build_sources([{"document_id": "uuid-9", "metadata": None}]) == ["uuid-9"]
 


### PR DESCRIPTION
First finding from the live smoke test: `/v1/rag` sources were still raw UUIDs despite issue #30 Part 4.

Root cause: the vector store's search response nests `canonical_id`/`relative_path` under `metadata.source_metadata` (see `vectors.py`), but `build_sources` only checked the flat top level — a shape that never occurs in production for repo chunks. The Part 4 unit tests were written against that flat shape, so they stayed green while the live path fell through to `document_id`.

`build_sources` now checks both levels — the same duality `extract_canonical_ids_from_chunks` already handles — and the new tests use the exact nested shape captured from the live stack.

Orchestrator: 69 passed.