### PR TITLE
Raise default LLM timeout to 600s (live smoke finding)

### DIFF
--- a/llm_service/models.yaml
+++ b/llm_service/models.yaml
@@ -20,5 +20,9 @@ fallbacks:
 
 # Per-alias request timeout in seconds; `default` applies to everything
 # without an explicit entry (falls back to LLM_TIMEOUT env, 120 s).
+# 600 matches the pre-LiteLLM behavior: CPU-only Ollama regularly needs
+# >120 s to generate over a full RAG context (verified live — 120 s made
+# /generate time out on the smoke test's second query). Tighten per
+# alias for fast cloud models instead of lowering the default.
 timeouts:
-  default: 120
+  default: 600


### PR DESCRIPTION
Second finding from the live smoke test: WP-M1 shipped `timeouts.default: 120` in `models.yaml`, but CPU-only Ollama regularly needs longer than that over a full RAG context — the smoke test's second query hit `litellm.Timeout ... Timeout passed=120.0` and surfaced as a 503. The pre-LiteLLM client used a 600s timeout; this restores that as the default, keeping per-alias overrides as the mechanism to tighten fast cloud models.

llm_service: 28 passed.