### PR TITLE
Tailscale Ollama routing: env-activated remote default, named endpoints, live model discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,12 +38,16 @@ OLLAMA_MODEL=phi4-mini:latest
 #LLM_TIMEOUT=120
 # Path to the model-alias registry (default: llm_service/models.yaml)
 #MODELS_CONFIG_PATH=/app/llm_service/models.yaml
-# Remote Tailscale Ollama box (issue #43) — the DEFAULT generation route,
-# falling back to the Windows-local Ollama when unreachable. models.yaml
-# interpolates these; override here without editing committed config.
-#REMOTE_OLLAMA_BASE_URL=http://100.105.24.12:11434
+# Optional remote Ollama endpoint (issue #43) — machine-specific, so the
+# committed models.yaml only activates it when these are set here (this
+# file's real counterpart, .env, is gitignored). Setting the base URL
+# creates the `remote` alias + `tailscaleollamalinux` endpoint;
+# LLM_DEFAULT_ALIAS=remote makes it the default generation route with
+# automatic fallback to the host-local Ollama.
+#REMOTE_OLLAMA_BASE_URL=http://<your-tailscale-ip>:11434
 #REMOTE_OLLAMA_MODEL=Qwen3:4b
-# Per-step model for /v1/summarize (small + fast is plenty)
+#LLM_DEFAULT_ALIAS=remote
+# Per-step model for /v1/summarize (small + fast; rides the remote endpoint)
 #SUMMARIZE_MODEL=granite4:350m
 # Cloud provider API keys — env-only, read natively by LiteLLM.
 # NEVER commit real keys; requests can never carry keys.

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ OLLAMA_MODEL=phi4-mini:latest
 #LLM_TIMEOUT=120
 # Path to the model-alias registry (default: llm_service/models.yaml)
 #MODELS_CONFIG_PATH=/app/llm_service/models.yaml
+# Remote Tailscale Ollama box (issue #43) — the DEFAULT generation route,
+# falling back to the Windows-local Ollama when unreachable. models.yaml
+# interpolates these; override here without editing committed config.
+#REMOTE_OLLAMA_BASE_URL=http://100.105.24.12:11434
+#REMOTE_OLLAMA_MODEL=Qwen3:4b
+# Per-step model for /v1/summarize (small + fast is plenty)
+#SUMMARIZE_MODEL=granite4:350m
 # Cloud provider API keys — env-only, read natively by LiteLLM.
 # NEVER commit real keys; requests can never carry keys.
 #OPENAI_API_KEY=

--- a/ingestion_service/src/ui/gradio_app.py
+++ b/ingestion_service/src/ui/gradio_app.py
@@ -172,6 +172,12 @@ def refresh_models():
             (f"{m['alias']} — {m['model']}", m["alias"])
             for m in data.get("models", [])
         ]
+        # issue #43: named endpoints expose their live model inventory so
+        # any remote model is directly pickable as <endpoint>/<model>
+        for endpoint in data.get("endpoints", []):
+            for model_name in endpoint.get("available_models") or []:
+                combo = f"{endpoint['name']}/{model_name}"
+                choices.append((combo, combo))
         return gr.Dropdown(
             choices=choices,
             value=data.get("default"),

--- a/llm_service/models.yaml
+++ b/llm_service/models.yaml
@@ -1,32 +1,44 @@
 # llm_service model registry (WP-M1, endpoints per issue #43).
 #
 # Friendly aliases -> LiteLLM model strings. Every string value supports
-# ${VAR} / ${VAR:default} environment interpolation, so machine-specific
-# endpoints and model choices are overridable via .env without editing
-# this file. Raw LiteLLM strings (containing "/") always pass through
-# verbatim, and `<endpoint>/<model>` routes any model the user believes
-# exists to that named endpoint.
+# ${VAR} / ${VAR:default} environment interpolation. This committed file
+# is UNIVERSAL: it must work for anyone who clones the repo. Machine-
+# specific inference endpoints (e.g. a Tailscale-reachable GPU box)
+# declare their api_base as ${SOME_VAR:} — with the env var unset the
+# entry simply doesn't exist; setting the var in your gitignored .env
+# activates it. LLM_DEFAULT_ALIAS promotes any alias to the default
+# route for this machine.
+#
+# Example personal .env for a remote Ollama default:
+#   REMOTE_OLLAMA_BASE_URL=http://<tailscale-ip>:11434
+#   REMOTE_OLLAMA_MODEL=Qwen3:4b
+#   LLM_DEFAULT_ALIAS=remote
+#
+# Raw LiteLLM strings (containing "/") always pass through verbatim, and
+# `<endpoint>/<model>` routes any model the user believes exists to that
+# named endpoint.
 #
 # API keys are env-only (OPENAI_API_KEY, ANTHROPIC_API_KEY, GROQ_API_KEY,
-# ...) — LiteLLM reads them natively. Never put keys in this file.
+# ...) — LiteLLM reads them natively. Never put keys or machine-specific
+# addresses in this file.
 
 models:
-  # Default route: the Tailscale-reachable Linux Ollama box (GTX 1080 Ti)
-  # — larger GPU-run models; falls back to the Windows-local Ollama when
-  # the tailnet is unreachable (see fallbacks).
-  default:
-    model: ollama/${REMOTE_OLLAMA_MODEL:Qwen3:4b}
-    api_base: ${REMOTE_OLLAMA_BASE_URL:http://100.105.24.12:11434}
-    timeout: 300
-  # Windows-host Ollama — the fallback and the offline route.
+  # Windows/host-local Ollama — works out of the box for every clone.
   local:
     model: ollama/${OLLAMA_MODEL:phi4-mini:latest}
     # api_base omitted -> OLLAMA_BASE_URL (host.docker.internal)
-  # Per-step model: /v1/summarize uses this alias when the request
-  # doesn't specify one — a small fast model is plenty for summaries.
+  # Remote Ollama box — exists only when REMOTE_OLLAMA_BASE_URL is set.
+  # Promote it to the default route with LLM_DEFAULT_ALIAS=remote.
+  remote:
+    model: ollama/${REMOTE_OLLAMA_MODEL:Qwen3:4b}
+    api_base: ${REMOTE_OLLAMA_BASE_URL:}
+    timeout: 300
+  # Per-step model for /v1/summarize (small + fast is plenty). Exists
+  # only alongside the remote endpoint; without it, summaries use the
+  # default route.
   summarize:
     model: ollama/${SUMMARIZE_MODEL:granite4:350m}
-    api_base: ${REMOTE_OLLAMA_BASE_URL:http://100.105.24.12:11434}
+    api_base: ${REMOTE_OLLAMA_BASE_URL:}
     timeout: 180
   fast: anthropic/claude-haiku-4-5
   smart: anthropic/claude-sonnet-5
@@ -35,10 +47,11 @@ models:
 # Named inference endpoints: `model=<name>/<anything>` routes that model
 # string to the endpoint's api_base with its LiteLLM provider prefix.
 # GET /v1/models lists these with a live model inventory when reachable.
+# Entries with an unset api_base env var don't exist.
 endpoints:
   tailscaleollamalinux:
     provider: ollama
-    api_base: ${REMOTE_OLLAMA_BASE_URL:http://100.105.24.12:11434}
+    api_base: ${REMOTE_OLLAMA_BASE_URL:}
     timeout: 300
   windowsollamalocal:
     provider: ollama
@@ -47,8 +60,11 @@ endpoints:
 
 # WP-M2 fallback chains. Keys may be aliases or endpoint names; targets
 # are aliases, tried in order after the primary fails (2 retries each).
+# `default: [local]` is harmless when default IS local (duplicates
+# collapse) and gives remote-default machines automatic local fallback.
 fallbacks:
   default: [local]
+  remote: [local]
   summarize: [local]
   tailscaleollamalinux: [local]
   smart: [gpt, default]
@@ -56,6 +72,6 @@ fallbacks:
 # Per-alias request timeout in seconds; `default` applies to everything
 # without an explicit entry (falls back to LLM_TIMEOUT env, 120 s).
 # 600 matches CPU-only local Ollama needs (verified live — 120 s made
-# /generate time out); the remote GPU box uses tighter per-alias values.
+# /generate time out); remote GPU entries use tighter per-alias values.
 timeouts:
   default: 600

--- a/llm_service/models.yaml
+++ b/llm_service/models.yaml
@@ -1,28 +1,61 @@
-# llm_service model registry (WP-M1).
+# llm_service model registry (WP-M1, endpoints per issue #43).
 #
-# Friendly aliases -> LiteLLM model strings. The `default` alias is
-# optional here: when absent it is derived from the OLLAMA_MODEL env var
-# (ollama/<OLLAMA_MODEL>), preserving the pre-LiteLLM default behavior.
-# Raw LiteLLM strings (containing "/") always pass through verbatim, so
-# power users are not limited to this menu.
+# Friendly aliases -> LiteLLM model strings. Every string value supports
+# ${VAR} / ${VAR:default} environment interpolation, so machine-specific
+# endpoints and model choices are overridable via .env without editing
+# this file. Raw LiteLLM strings (containing "/") always pass through
+# verbatim, and `<endpoint>/<model>` routes any model the user believes
+# exists to that named endpoint.
 #
-# API keys are env-only (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...) —
-# LiteLLM reads them natively. Never put keys in this file.
+# API keys are env-only (OPENAI_API_KEY, ANTHROPIC_API_KEY, GROQ_API_KEY,
+# ...) — LiteLLM reads them natively. Never put keys in this file.
 
 models:
+  # Default route: the Tailscale-reachable Linux Ollama box (GTX 1080 Ti)
+  # — larger GPU-run models; falls back to the Windows-local Ollama when
+  # the tailnet is unreachable (see fallbacks).
+  default:
+    model: ollama/${REMOTE_OLLAMA_MODEL:Qwen3:4b}
+    api_base: ${REMOTE_OLLAMA_BASE_URL:http://100.105.24.12:11434}
+    timeout: 300
+  # Windows-host Ollama — the fallback and the offline route.
+  local:
+    model: ollama/${OLLAMA_MODEL:phi4-mini:latest}
+    # api_base omitted -> OLLAMA_BASE_URL (host.docker.internal)
+  # Per-step model: /v1/summarize uses this alias when the request
+  # doesn't specify one — a small fast model is plenty for summaries.
+  summarize:
+    model: ollama/${SUMMARIZE_MODEL:granite4:350m}
+    api_base: ${REMOTE_OLLAMA_BASE_URL:http://100.105.24.12:11434}
+    timeout: 180
   fast: anthropic/claude-haiku-4-5
   smart: anthropic/claude-sonnet-5
   gpt: openai/gpt-5.1
 
-# WP-M2 (resilience) consumes this map: alias -> ordered fallback aliases.
+# Named inference endpoints: `model=<name>/<anything>` routes that model
+# string to the endpoint's api_base with its LiteLLM provider prefix.
+# GET /v1/models lists these with a live model inventory when reachable.
+endpoints:
+  tailscaleollamalinux:
+    provider: ollama
+    api_base: ${REMOTE_OLLAMA_BASE_URL:http://100.105.24.12:11434}
+    timeout: 300
+  windowsollamalocal:
+    provider: ollama
+    api_base: ${OLLAMA_BASE_URL:http://host.docker.internal:11434}
+    timeout: 600
+
+# WP-M2 fallback chains. Keys may be aliases or endpoint names; targets
+# are aliases, tried in order after the primary fails (2 retries each).
 fallbacks:
+  default: [local]
+  summarize: [local]
+  tailscaleollamalinux: [local]
   smart: [gpt, default]
 
 # Per-alias request timeout in seconds; `default` applies to everything
 # without an explicit entry (falls back to LLM_TIMEOUT env, 120 s).
-# 600 matches the pre-LiteLLM behavior: CPU-only Ollama regularly needs
-# >120 s to generate over a full RAG context (verified live — 120 s made
-# /generate time out on the smoke test's second query). Tighten per
-# alias for fast cloud models instead of lowering the default.
+# 600 matches CPU-only local Ollama needs (verified live — 120 s made
+# /generate time out); the remote GPU box uses tighter per-alias values.
 timeouts:
   default: 600

--- a/llm_service/src/api/v1/main.py
+++ b/llm_service/src/api/v1/main.py
@@ -1,5 +1,8 @@
 # llm-service/src/api/v1/main.py - MS7-IS2 FIXED
+import asyncio
 import logging
+
+import httpx
 from fastapi import FastAPI, Query
 from fastapi.responses import JSONResponse
 
@@ -53,10 +56,40 @@ async def generate(
         logging.exception("Error in /generate")
         return JSONResponse(status_code=500, content={"error": str(e)})
 
+async def _endpoint_inventory(endpoint: dict) -> dict:
+    """issue #43: enrich a named endpoint with its live model list so
+    the UI can offer `<endpoint>/<model>` choices. Best-effort — an
+    unreachable endpoint reports available_models: null and the menu
+    still renders."""
+    entry = dict(endpoint)
+    entry["available_models"] = None
+    if entry.get("provider") != "ollama":
+        return entry
+    try:
+        async with httpx.AsyncClient(timeout=3) as client:
+            resp = await client.get(f"{entry['api_base']}/api/tags")
+            resp.raise_for_status()
+            entry["available_models"] = sorted(
+                m["name"] for m in resp.json().get("models", [])
+            )
+    except Exception as e:
+        logging.debug("Endpoint %s inventory failed: %s", entry["name"], e)
+    return entry
+
+
 @app.get("/v1/models")
-def list_models() -> dict:
-    """WP-M5: the model menu — aliases from models.yaml + the default."""
-    return {"models": get_registry().describe(), "default": DEFAULT_ALIAS}
+async def list_models() -> dict:
+    """WP-M5 + issue #43: aliases from models.yaml, the default, and
+    named endpoints with live model inventories."""
+    registry = get_registry()
+    endpoints = await asyncio.gather(
+        *(_endpoint_inventory(e) for e in registry.describe_endpoints())
+    )
+    return {
+        "models": registry.describe(),
+        "default": DEFAULT_ALIAS,
+        "endpoints": list(endpoints),
+    }
 
 
 @app.get("/health")

--- a/llm_service/src/api/v1/summarize.py
+++ b/llm_service/src/api/v1/summarize.py
@@ -6,6 +6,7 @@ import httpx
 from fastapi import APIRouter, HTTPException, Query
 
 from src.core.llm_client import generate_completion
+from src.core.model_registry import get_registry
 
 router = APIRouter(prefix="/v1/summarize", tags=["summaries"])
 logging.basicConfig(level=logging.DEBUG)
@@ -64,8 +65,13 @@ async def generate_summary(
 ):
     """MS7-IS2: Generate LLM summary for document ingestion.
 
-    WP-M5: honors the model alias/provider params like /generate does;
-    omitted → the registry's default model (previously hardcoded)."""
+    WP-M5: honors the model alias/provider params like /generate does.
+    Omitted → the `summarize` step alias when models.yaml defines one
+    (per-step model selection, issue #43), else the registry default."""
+    if model is None and provider is None and get_registry().has_alias(
+        "summarize"
+    ):
+        model = "summarize"
     try:
         logger.info(f"summarize.py generate_summary: {ingestion_id}")
         UUID(ingestion_id)  # validate format

--- a/llm_service/src/core/model_registry.py
+++ b/llm_service/src/core/model_registry.py
@@ -16,15 +16,34 @@ or a mapping for endpoint-specific routing:
       api_base: http://gpu-box.tailnet:11434
       timeout: 300
 
+Named endpoints (issue #43) let a user route an arbitrary model to a
+specific inference host — "pick tailscaleollamalinux and whatever model
+is available there" — without pre-registering every model:
+
+    endpoints:
+      tailscaleollamalinux:
+        provider: ollama
+        api_base: http://100.105.24.12:11434
+        timeout: 300
+
+makes `model=tailscaleollamalinux/Qwen3:8b` resolve to
+`ollama/Qwen3:8b` at that api_base. Endpoint names also work as keys in
+`fallbacks`, so an endpoint can degrade to an alias when unreachable.
+
+Every string value in models.yaml supports `${VAR}` / `${VAR:default}`
+environment interpolation, so machine-specific addresses stay
+overridable without editing committed config.
+
 Resolution order for an incoming request:
-alias -> raw LiteLLM string (contains "/") -> legacy (provider, model)
-pair -> error listing valid aliases. The `default` alias, when absent
-from the yaml, derives from OLLAMA_MODEL to preserve pre-LiteLLM
-behavior.
+alias -> endpoint-prefixed (`<endpoint>/<model>`) -> raw LiteLLM string
+(contains "/") -> legacy (provider, model) pair -> error listing valid
+aliases. The `default` alias, when absent from the yaml, derives from
+OLLAMA_MODEL to preserve pre-LiteLLM behavior.
 """
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -34,6 +53,23 @@ import yaml
 from src.core.config import LLM_TIMEOUT, OLLAMA_BASE_URL, OLLAMA_MODEL
 
 DEFAULT_ALIAS = "default"
+
+# ${VAR} or ${VAR:default} — the default may itself contain colons
+# (model tags like phi4-mini:latest, URLs like http://host:11434).
+_ENV_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::([^}]*))?\}")
+
+
+def _interpolate_env(value: Any) -> Any:
+    """Recursively substitute ${VAR}/${VAR:default} in string values."""
+    if isinstance(value, str):
+        return _ENV_PATTERN.sub(
+            lambda m: os.getenv(m.group(1), m.group(2) or ""), value
+        )
+    if isinstance(value, dict):
+        return {k: _interpolate_env(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_interpolate_env(v) for v in value]
+    return value
 
 
 class UnknownModelAliasError(ValueError):
@@ -59,6 +95,7 @@ class ResolvedModel:
 
 class ModelRegistry:
     def __init__(self, config: Dict[str, Any]):
+        config = _interpolate_env(config)
         raw_models = config.get("models") or {}
         self._aliases: Dict[str, Dict[str, Any]] = {}
         for alias, value in raw_models.items():
@@ -68,6 +105,12 @@ class ModelRegistry:
                 self._aliases[alias] = dict(value)
         if DEFAULT_ALIAS not in self._aliases:
             self._aliases[DEFAULT_ALIAS] = {"model": f"ollama/{OLLAMA_MODEL}"}
+
+        # issue #43: named inference endpoints for arbitrary-model routing
+        self._endpoints: Dict[str, Dict[str, Any]] = {}
+        for name, value in (config.get("endpoints") or {}).items():
+            if isinstance(value, dict) and "api_base" in value:
+                self._endpoints[name] = dict(value)
 
         self.fallbacks: Dict[str, List[str]] = config.get("fallbacks") or {}
         self._timeouts: Dict[str, Any] = config.get("timeouts") or {}
@@ -79,6 +122,9 @@ class ModelRegistry:
     def aliases(self) -> List[str]:
         return sorted(self._aliases)
 
+    def has_alias(self, name: str) -> bool:
+        return name in self._aliases
+
     def describe(self) -> List[Dict[str, Any]]:
         """Alias menu for GET /v1/models (WP-M5)."""
         return [
@@ -88,6 +134,18 @@ class ModelRegistry:
                 "is_default": alias == DEFAULT_ALIAS,
             }
             for alias in self.aliases()
+        ]
+
+    def describe_endpoints(self) -> List[Dict[str, Any]]:
+        """Named endpoints for GET /v1/models (issue #43). The caller
+        may enrich each entry with live model listings."""
+        return [
+            {
+                "name": name,
+                "provider": entry.get("provider", "ollama"),
+                "api_base": entry["api_base"],
+            }
+            for name, entry in sorted(self._endpoints.items())
         ]
 
     def fallback_chain(self, primary: ResolvedModel) -> List[ResolvedModel]:
@@ -126,6 +184,17 @@ class ModelRegistry:
             return self._from_alias(model)
 
         if "/" in model:
+            prefix, remainder = model.split("/", 1)
+            if prefix in self._endpoints and remainder:
+                # issue #43: `<endpoint>/<any model>` routes the model to
+                # that endpoint's api_base — the user picks whatever they
+                # believe is available there. The endpoint name doubles
+                # as the alias so fallbacks/timeouts keyed by it apply.
+                entry = self._endpoints[prefix]
+                litellm_provider = entry.get("provider", "ollama")
+                return self._finalize(
+                    prefix, f"{litellm_provider}/{remainder}", entry
+                )
             # raw LiteLLM string passes through verbatim
             return self._finalize(None, model, {})
 

--- a/llm_service/src/core/model_registry.py
+++ b/llm_service/src/core/model_registry.py
@@ -100,16 +100,33 @@ class ModelRegistry:
         self._aliases: Dict[str, Dict[str, Any]] = {}
         for alias, value in raw_models.items():
             if isinstance(value, str):
-                self._aliases[alias] = {"model": value}
+                entry: Dict[str, Any] = {"model": value}
             elif isinstance(value, dict) and "model" in value:
-                self._aliases[alias] = dict(value)
+                entry = dict(value)
+            else:
+                continue
+            # Machine-specific entries declare api_base via env
+            # interpolation with an empty default; when the env var is
+            # unset the entry vanishes, keeping the committed yaml
+            # universal (issue #43 — the Tailscale box is one user's
+            # setup, not the repo's).
+            if entry.get("api_base") == "":
+                continue
+            self._aliases[alias] = entry
+
+        # LLM_DEFAULT_ALIAS promotes an existing alias to the default
+        # route (e.g. remote on the machine that has the tailnet box);
+        # unset or unknown -> the plain default below.
+        promoted = os.getenv("LLM_DEFAULT_ALIAS")
+        if promoted and promoted in self._aliases:
+            self._aliases[DEFAULT_ALIAS] = dict(self._aliases[promoted])
         if DEFAULT_ALIAS not in self._aliases:
             self._aliases[DEFAULT_ALIAS] = {"model": f"ollama/{OLLAMA_MODEL}"}
 
         # issue #43: named inference endpoints for arbitrary-model routing
         self._endpoints: Dict[str, Dict[str, Any]] = {}
         for name, value in (config.get("endpoints") or {}).items():
-            if isinstance(value, dict) and "api_base" in value:
+            if isinstance(value, dict) and value.get("api_base"):
                 self._endpoints[name] = dict(value)
 
         self.fallbacks: Dict[str, List[str]] = config.get("fallbacks") or {}

--- a/llm_service/tests/api/test_models_endpoint.py
+++ b/llm_service/tests/api/test_models_endpoint.py
@@ -1,7 +1,10 @@
 # llm_service/tests/api/test_models_endpoint.py
 """
-WP-M5: GET /v1/models lists aliases and marks the default.
+WP-M5 + issue #43: GET /v1/models lists aliases, the default, and named
+endpoints with live model inventories (best-effort).
 """
+import httpx
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api.v1.main import app
@@ -9,7 +12,28 @@ from src.api.v1.main import app
 client = TestClient(app)
 
 
-def test_models_endpoint_lists_aliases_with_default():
+@pytest.fixture()
+def fake_endpoints(monkeypatch):
+    """Serve /api/tags for the remote endpoint; refuse the local one —
+    keeps unit tests off the network either way."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "100.105.24.12" in str(request.url):
+            return httpx.Response(200, json={"models": [
+                {"name": "Qwen3:4b"}, {"name": "deepseek-r1:7b"},
+            ]})
+        raise httpx.ConnectError("unreachable")
+
+    real_async_client = httpx.AsyncClient
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+
+def test_models_endpoint_lists_aliases_with_default(fake_endpoints):
     response = client.get("/v1/models")
 
     assert response.status_code == 200
@@ -18,10 +42,55 @@ def test_models_endpoint_lists_aliases_with_default():
 
     by_alias = {m["alias"]: m for m in body["models"]}
     assert by_alias["default"]["is_default"] is True
-    # aliases shipped in llm_service/models.yaml
+    assert by_alias["default"]["model"] == "ollama/Qwen3:4b"
+    assert "local" in by_alias
+    assert "summarize" in by_alias
     assert "smart" in by_alias
     assert by_alias["smart"]["model"] == "anthropic/claude-sonnet-5"
     assert by_alias["smart"]["is_default"] is False
+
+
+def test_models_endpoint_reports_live_endpoint_inventory(fake_endpoints):
+    body = client.get("/v1/models").json()
+    endpoints = {e["name"]: e for e in body["endpoints"]}
+
+    # reachable endpoint lists its models, sorted
+    assert endpoints["tailscaleollamalinux"]["available_models"] == [
+        "Qwen3:4b", "deepseek-r1:7b",
+    ]
+    # unreachable endpoint degrades to null, menu still renders
+    assert endpoints["windowsollamalocal"]["available_models"] is None
+
+
+def test_summarize_defaults_to_step_alias(monkeypatch):
+    """issue #43 per-step models: /v1/summarize without params uses the
+    `summarize` alias from models.yaml."""
+    captured = {}
+
+    async def fake_fetch_chunks(ingestion_id):
+        return ["chunk text"]
+
+    async def fake_update(ingestion_id, summary):
+        return None
+
+    async def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {"response": "a summary"}
+
+    monkeypatch.setattr("src.api.v1.summarize.fetch_chunks", fake_fetch_chunks)
+    monkeypatch.setattr(
+        "src.api.v1.summarize.update_document_summary", fake_update
+    )
+    monkeypatch.setattr(
+        "src.api.v1.summarize.generate_completion", fake_generate
+    )
+
+    response = client.post(
+        "/v1/summarize/123e4567-e89b-12d3-a456-426614174000"
+    )
+
+    assert response.status_code == 200
+    assert captured["model"] == "summarize"
 
 
 def test_summarize_forwards_model_alias(monkeypatch):

--- a/llm_service/tests/api/test_models_endpoint.py
+++ b/llm_service/tests/api/test_models_endpoint.py
@@ -33,7 +33,21 @@ def fake_endpoints(monkeypatch):
     monkeypatch.setattr(httpx, "AsyncClient", patched_client)
 
 
-def test_models_endpoint_lists_aliases_with_default(fake_endpoints):
+@pytest.fixture()
+def remote_env(monkeypatch):
+    """Machine-specific remote endpoint activated via env (the way the
+    gitignored .env does it); registry reloaded around the test."""
+    from src.core.model_registry import reset_registry
+
+    monkeypatch.setenv("REMOTE_OLLAMA_BASE_URL", "http://100.105.24.12:11434")
+    reset_registry()
+    yield
+    reset_registry()
+
+
+def test_models_endpoint_universal_without_remote_env(fake_endpoints):
+    """A fresh clone (no remote env vars) sees only universal entries —
+    no machine-specific aliases or endpoints."""
     response = client.get("/v1/models")
 
     assert response.status_code == 200
@@ -42,18 +56,24 @@ def test_models_endpoint_lists_aliases_with_default(fake_endpoints):
 
     by_alias = {m["alias"]: m for m in body["models"]}
     assert by_alias["default"]["is_default"] is True
-    assert by_alias["default"]["model"] == "ollama/Qwen3:4b"
     assert "local" in by_alias
-    assert "summarize" in by_alias
     assert "smart" in by_alias
-    assert by_alias["smart"]["model"] == "anthropic/claude-sonnet-5"
-    assert by_alias["smart"]["is_default"] is False
+    assert "remote" not in by_alias
+    assert "summarize" not in by_alias
+
+    endpoint_names = {e["name"] for e in body["endpoints"]}
+    assert "tailscaleollamalinux" not in endpoint_names
+    assert "windowsollamalocal" in endpoint_names
 
 
-def test_models_endpoint_reports_live_endpoint_inventory(fake_endpoints):
+def test_models_endpoint_with_remote_env(remote_env, fake_endpoints):
     body = client.get("/v1/models").json()
-    endpoints = {e["name"]: e for e in body["endpoints"]}
 
+    by_alias = {m["alias"]: m for m in body["models"]}
+    assert "remote" in by_alias
+    assert "summarize" in by_alias
+
+    endpoints = {e["name"]: e for e in body["endpoints"]}
     # reachable endpoint lists its models, sorted
     assert endpoints["tailscaleollamalinux"]["available_models"] == [
         "Qwen3:4b", "deepseek-r1:7b",
@@ -62,9 +82,9 @@ def test_models_endpoint_reports_live_endpoint_inventory(fake_endpoints):
     assert endpoints["windowsollamalocal"]["available_models"] is None
 
 
-def test_summarize_defaults_to_step_alias(monkeypatch):
+def test_summarize_defaults_to_step_alias(remote_env, monkeypatch):
     """issue #43 per-step models: /v1/summarize without params uses the
-    `summarize` alias from models.yaml."""
+    `summarize` alias when the remote env activates it."""
     captured = {}
 
     async def fake_fetch_chunks(ingestion_id):

--- a/llm_service/tests/core/test_llm_client_litellm.py
+++ b/llm_service/tests/core/test_llm_client_litellm.py
@@ -44,15 +44,24 @@ def capture(monkeypatch):
     return calls
 
 
-async def test_no_params_uses_ollama_default_as_before(capture):
-    """Regression: /generate with no params answers via Ollama exactly
-    as before the LiteLLM swap."""
+async def test_no_params_routes_to_remote_default(capture):
+    """issue #43: /generate with no params targets the remote Tailscale
+    Ollama box (models.yaml default alias, env-overridable); the
+    Windows-local Ollama is the configured fallback, not the default."""
     result = await llm_client.generate_completion(context="c", query="q")
+
+    assert capture["model"] == "ollama/Qwen3:4b"
+    assert capture["api_base"] == "http://100.105.24.12:11434"
+    assert result["provider"] == "ollama"
+    assert result["model_alias"] == "default"
+    assert result["response"] == "the answer"
+
+
+async def test_local_alias_targets_windows_ollama(capture):
+    await llm_client.generate_completion(context="c", query="q", model="local")
 
     assert capture["model"] == f"ollama/{OLLAMA_MODEL}"
     assert capture["api_base"] == OLLAMA_BASE_URL
-    assert result["provider"] == "ollama"
-    assert result["response"] == "the answer"
 
 
 async def test_messages_carry_system_and_user_roles(capture):

--- a/llm_service/tests/core/test_llm_client_litellm.py
+++ b/llm_service/tests/core/test_llm_client_litellm.py
@@ -44,20 +44,36 @@ def capture(monkeypatch):
     return calls
 
 
-async def test_no_params_routes_to_remote_default(capture):
-    """issue #43: /generate with no params targets the remote Tailscale
-    Ollama box (models.yaml default alias, env-overridable); the
-    Windows-local Ollama is the configured fallback, not the default."""
+async def test_no_params_uses_local_ollama_default(capture):
+    """Universal default for a fresh clone: with no remote env vars set,
+    /generate answers via the host-local Ollama exactly as before."""
     result = await llm_client.generate_completion(context="c", query="q")
 
-    assert capture["model"] == "ollama/Qwen3:4b"
-    assert capture["api_base"] == "http://100.105.24.12:11434"
+    assert capture["model"] == f"ollama/{OLLAMA_MODEL}"
+    assert capture["api_base"] == OLLAMA_BASE_URL
     assert result["provider"] == "ollama"
-    assert result["model_alias"] == "default"
     assert result["response"] == "the answer"
 
 
-async def test_local_alias_targets_windows_ollama(capture):
+async def test_remote_env_promotes_remote_default(capture, monkeypatch):
+    """issue #43: setting REMOTE_OLLAMA_BASE_URL + LLM_DEFAULT_ALIAS in
+    the (gitignored) .env makes the remote box the default route —
+    machine-specific config, never committed."""
+    from src.core.model_registry import reset_registry
+
+    monkeypatch.setenv("REMOTE_OLLAMA_BASE_URL", "http://100.105.24.12:11434")
+    monkeypatch.setenv("LLM_DEFAULT_ALIAS", "remote")
+    reset_registry()
+    try:
+        result = await llm_client.generate_completion(context="c", query="q")
+        assert capture["model"] == "ollama/Qwen3:4b"
+        assert capture["api_base"] == "http://100.105.24.12:11434"
+        assert result["model_alias"] == "default"
+    finally:
+        reset_registry()
+
+
+async def test_local_alias_targets_host_ollama(capture):
     await llm_client.generate_completion(context="c", query="q", model="local")
 
     assert capture["model"] == f"ollama/{OLLAMA_MODEL}"

--- a/llm_service/tests/core/test_model_registry.py
+++ b/llm_service/tests/core/test_model_registry.py
@@ -93,3 +93,102 @@ def test_describe_lists_aliases_with_default_flag(registry):
     aliases = {entry["alias"]: entry for entry in menu}
     assert aliases["default"]["is_default"] is True
     assert aliases["smart"]["is_default"] is False
+
+
+# ------------------------------------------------------------------
+# issue #43: env interpolation + named endpoints
+# ------------------------------------------------------------------
+
+ENDPOINT_CONFIG = {
+    "models": {
+        "default": {
+            "model": "ollama/${TEST_REMOTE_MODEL:Qwen3:4b}",
+            "api_base": "${TEST_REMOTE_BASE:http://100.105.24.12:11434}",
+            "timeout": 300,
+        },
+        "local": {"model": "ollama/phi4-mini:latest"},
+    },
+    "endpoints": {
+        "tailscaleollamalinux": {
+            "provider": "ollama",
+            "api_base": "${TEST_REMOTE_BASE:http://100.105.24.12:11434}",
+            "timeout": 300,
+        },
+        "windowsollamalocal": {
+            "provider": "ollama",
+            "api_base": "http://host.docker.internal:11434",
+        },
+    },
+    "fallbacks": {
+        "default": ["local"],
+        "tailscaleollamalinux": ["local"],
+    },
+    "timeouts": {"default": 600},
+}
+
+
+def test_env_interpolation_uses_defaults_with_colons():
+    registry = ModelRegistry(ENDPOINT_CONFIG)
+    resolved = registry.resolve(None, None)
+    # defaults after the first colon survive intact (model tags, URLs)
+    assert resolved.model == "ollama/Qwen3:4b"
+    assert resolved.api_base == "http://100.105.24.12:11434"
+
+
+def test_env_interpolation_prefers_environment(monkeypatch):
+    monkeypatch.setenv("TEST_REMOTE_MODEL", "deepseek-r1:7b")
+    monkeypatch.setenv("TEST_REMOTE_BASE", "http://10.0.0.9:11434")
+    registry = ModelRegistry(ENDPOINT_CONFIG)
+    resolved = registry.resolve(None, None)
+    assert resolved.model == "ollama/deepseek-r1:7b"
+    assert resolved.api_base == "http://10.0.0.9:11434"
+
+
+def test_endpoint_prefixed_model_routes_to_endpoint():
+    """The user picks tailscaleollamalinux plus any model they believe
+    is available there — no pre-registration required."""
+    registry = ModelRegistry(ENDPOINT_CONFIG)
+    resolved = registry.resolve(None, "tailscaleollamalinux/qwen2.5-coder:latest")
+    assert resolved.model == "ollama/qwen2.5-coder:latest"
+    assert resolved.api_base == "http://100.105.24.12:11434"
+    assert resolved.alias == "tailscaleollamalinux"
+    assert resolved.timeout == 300.0
+
+
+def test_endpoint_name_keys_fallback_chain():
+    registry = ModelRegistry(ENDPOINT_CONFIG)
+    primary = registry.resolve(None, "tailscaleollamalinux/Qwen3:8b")
+    chain = registry.fallback_chain(primary)
+    assert [c.model for c in chain] == [
+        "ollama/Qwen3:8b",
+        "ollama/phi4-mini:latest",
+    ]
+
+
+def test_remote_default_falls_back_to_local():
+    registry = ModelRegistry(ENDPOINT_CONFIG)
+    chain = registry.fallback_chain(registry.resolve(None, None))
+    assert [c.model for c in chain] == [
+        "ollama/Qwen3:4b",
+        "ollama/phi4-mini:latest",
+    ]
+    # local fallback keeps the Windows-host api_base default
+    assert chain[1].api_base == OLLAMA_BASE_URL
+
+
+def test_unknown_prefix_still_passes_through_as_raw():
+    registry = ModelRegistry(ENDPOINT_CONFIG)
+    resolved = registry.resolve(None, "groq/llama-3.1-8b-instant")
+    assert resolved.alias is None
+    assert resolved.model == "groq/llama-3.1-8b-instant"
+    assert resolved.api_base is None
+
+
+def test_describe_endpoints_shape():
+    registry = ModelRegistry(ENDPOINT_CONFIG)
+    endpoints = {e["name"]: e for e in registry.describe_endpoints()}
+    assert endpoints["tailscaleollamalinux"]["provider"] == "ollama"
+    assert endpoints["tailscaleollamalinux"]["api_base"] == (
+        "http://100.105.24.12:11434"
+    )
+    assert "windowsollamalocal" in endpoints

--- a/llm_service/tests/core/test_model_registry.py
+++ b/llm_service/tests/core/test_model_registry.py
@@ -192,3 +192,51 @@ def test_describe_endpoints_shape():
         "http://100.105.24.12:11434"
     )
     assert "windowsollamalocal" in endpoints
+
+
+def test_empty_api_base_entries_are_pruned():
+    """Machine-specific entries with an unset env var (empty api_base)
+    must not exist — the committed yaml stays universal."""
+    registry = ModelRegistry({
+        "models": {
+            "local": "ollama/phi4-mini:latest",
+            "remote": {"model": "ollama/big", "api_base": "${UNSET_XYZ_VAR:}"},
+        },
+        "endpoints": {
+            "tail": {"provider": "ollama", "api_base": "${UNSET_XYZ_VAR:}"},
+        },
+    })
+    assert not registry.has_alias("remote")
+    assert registry.describe_endpoints() == []
+    # default falls back to the built-in local derivation
+    assert registry.resolve(None, None).model == f"ollama/{OLLAMA_MODEL}"
+
+
+def test_llm_default_alias_promotes_remote(monkeypatch):
+    monkeypatch.setenv("PROMO_BASE_XYZ", "http://gpu-box:11434")
+    monkeypatch.setenv("LLM_DEFAULT_ALIAS", "remote")
+    registry = ModelRegistry({
+        "models": {
+            "local": "ollama/phi4-mini:latest",
+            "remote": {"model": "ollama/big", "api_base": "${PROMO_BASE_XYZ:}"},
+        },
+        "fallbacks": {"default": ["local"]},
+    })
+    resolved = registry.resolve(None, None)
+    assert resolved.model == "ollama/big"
+    assert resolved.api_base == "http://gpu-box:11434"
+    chain = registry.fallback_chain(resolved)
+    assert [c.model for c in chain] == ["ollama/big", "ollama/phi4-mini:latest"]
+
+
+def test_llm_default_alias_ignored_when_target_pruned(monkeypatch):
+    """LLM_DEFAULT_ALIAS=remote without the remote base URL set must not
+    break the default route."""
+    monkeypatch.setenv("LLM_DEFAULT_ALIAS", "remote")
+    registry = ModelRegistry({
+        "models": {
+            "local": "ollama/phi4-mini:latest",
+            "remote": {"model": "ollama/big", "api_base": "${UNSET_XYZ_VAR:}"},
+        },
+    })
+    assert registry.resolve(None, None).model == f"ollama/{OLLAMA_MODEL}"


### PR DESCRIPTION
Implements #43. Two commits: the routing feature, then a correction keeping the committed config universal.

**What a fresh clone gets (unchanged behavior):** local Ollama default, same aliases as before, plus a `windowsollamalocal` named endpoint. No machine-specific addresses in the repo.

**What a machine with a remote Ollama box gets (via gitignored `.env`):** setting `REMOTE_OLLAMA_BASE_URL` activates the `remote` + `summarize` aliases and the `tailscaleollamalinux` endpoint; `LLM_DEFAULT_ALIAS=remote` promotes it to the default route with automatic fallback to `local` (WP-M2 chain).

Mechanics:
- `${VAR}`/`${VAR:default}` env interpolation across models.yaml (defaults may contain colons — model tags, URLs); entries whose api_base interpolates empty are pruned.
- **Named endpoints**: `model=<endpoint>/<anything>` routes any model the user believes exists to that endpoint's api_base with its LiteLLM provider prefix; the endpoint name doubles as the alias so fallbacks/timeouts keyed by it apply.
- `GET /v1/models` adds endpoints with best-effort live `/api/tags` inventories (3 s probe, null on unreachable); Gradio dropdown offers `<endpoint>/<model>` choices.
- `/v1/summarize` uses the `summarize` step alias when defined (per-step models).

**Live-verified on the running stack**: container→tailnet reachability; menu shows both endpoints with real inventories; `/generate` with no params answered from `ollama/Qwen3:4b` on the remote box; `tailscaleollamalinux/qwen2.5-coder:latest` (arbitrary user pick) routed correctly; `local` still hits the Windows host. Outage fallback covered by unit tests (live drill = unplug tailnet).

Follow-up filed for first-class Groq/NVIDIA NIM.

llm_service 42 passed · orchestrator 69 · ingestion 94.

Closes #43