### PR TITLE
Add RAG quality evaluation methodology; reconcile roadmap with shipped work

### DIFF
--- a/DOCS/audit/00-Audit-Overview.md
+++ b/DOCS/audit/00-Audit-Overview.md
@@ -29,8 +29,19 @@ aliases:
 | [[05-Enterprise-Platform-Plan]] | Laptop → enterprise web product? | Auth, multi-tenancy, real frontend, K8s, observability — phased plan |
 | [[06-LLM-Provider-LiteLLM-Plan]] | LiteLLM + model switching? | Replace `llm_service` internals with LiteLLM Router; 2–3 day work package |
 | [[07-Roadmap]] | In what order? | 5 phases, each decomposed into agent-sized work packages |
+| [[08-RAG-Quality-Evaluation-Methodology]] | Is a reranker actually needed? | Not yet — verify chunking, retrieval recall, and clean-context generation first |
 
-## 🎯 Executive Summary
+## 📍 Current status (2026-07-20 — supersedes the maturity claim below)
+
+> [!tip] Phases 1–2 are implementation-complete and operationally hardened. RAG retrieval and answer quality have not yet been formally validated.
+
+- **Phase 1 (foundation) and Phase 2 (graph depth + LLM freedom) are done** — see [[07-Roadmap]], now checked off against actual merged PRs rather than aspirational checkboxes. O(N) graph build, batch/atomic persistence, HNSW indexing, full call/inheritance resolution, LiteLLM routing with a live remote-Ollama endpoint and fallback chain.
+- **Beyond the original plan**, reactive hardening from live Docker testing caught and fixed real defects: repo_id being dropped in the query path, source labels resolving to UUIDs instead of names, a fallback-chain timeout regression, and (ongoing) two-repo isolation / model-alias switching checks. This is evidence the infrastructure works, not evidence the RAG answers are good.
+- **What is not yet proven:** whether retrieval consistently surfaces the correct evidence, and whether generation produces grounded, complete answers from it. [[08-RAG-Quality-Evaluation-Methodology]] is the gate for this — Phase 4's reranker (`WP-S8` in [[04-Scalability-Plan]]) stays unstarted until that evaluation says it's the actual bottleneck.
+- **Phase 3 (multi-language) and the rest of Phase 4/5 are not started.**
+- A precise one-line status: *the platform works; whether it works well is not yet validated.*
+
+## 🎯 Executive Summary (as audited 2026-07-09 — historical; see status above for what has since shipped)
 
 The project has a **sound architectural thesis** — read-only, graph-aware code intelligence with deterministic canonical identity ([[../adr/ADR-031-canonical-identity-model|ADR-031]]) — and a clean service decomposition. The thesis is worth scaling. The implementation, however, is at **prototype maturity**:
 
@@ -43,17 +54,19 @@ The project has a **sound architectural thesis** — read-only, graph-aware code
 > [!tip] The single most important strategic decision
 > Introduce a **language-agnostic intermediate representation (IR)** for extraction (see [[03-Multi-Language-Graph-Plan]]) *before* deepening the Python graph. Deepen the graph **through** the IR, not through more Python-only code. Otherwise every Python-specific improvement becomes rework when Rust/TS/Java land.
 
-## 🧭 Priority Matrix
+## 🧭 Priority Matrix (as audited 2026-07-09 — historical; current priority is the RAG-quality baseline below)
 
-| Priority | Theme | Why now |
-|---|---|---|
-| 🔴 P0 | Correctness bugs in graph build ([[01-Codebase-Audit-Findings#P0 — Graph correctness]]) | Everything downstream reasons over wrong data |
-| 🔴 P0 | O(N²) ingestion hot loops | Blocks any repo beyond toy size |
-| 🟠 P1 | ANN index + batch embedding | Query latency and ingest throughput |
-| 🟠 P1 | LiteLLM provider abstraction | Unblocks enterprise LLM requirements; small effort |
-| 🟡 P2 | Tree-sitter IR + multi-language | The headline feature ask |
-| 🟡 P2 | Job queue + incremental ingestion | Massive-repo readiness |
-| 🟢 P3 | Auth / multi-tenancy / web frontend | Enterprise productization |
+| Priority | Theme | Why now | Status (2026-07-20) |
+|---|---|---|---|
+| 🔴 P0 | Correctness bugs in graph build ([[01-Codebase-Audit-Findings#P0 — Graph correctness]]) | Everything downstream reasons over wrong data | ✅ Done (Phase 1/2) |
+| 🔴 P0 | O(N²) ingestion hot loops | Blocks any repo beyond toy size | ✅ Done (WP-S1) |
+| 🟠 P1 | ANN index + batch embedding | Query latency and ingest throughput | ✅ Done (WP-S2/S4/S4B) |
+| 🟠 P1 | LiteLLM provider abstraction | Unblocks enterprise LLM requirements; small effort | ✅ Done + extended (PR #47); Groq/NIM tracked as issue #46 |
+| 🟡 P2 | Tree-sitter IR + multi-language | The headline feature ask | Not started (Phase 3) |
+| 🟡 P2 | Job queue + incremental ingestion | Massive-repo readiness | Not started (Phase 4) |
+| 🟢 P3 | Auth / multi-tenancy / web frontend | Enterprise productization | Not started (Phase 5) |
+
+**Current top priority (2026-07-20):** finish the outstanding live-smoke-test acceptance checks, then execute [[08-RAG-Quality-Evaluation-Methodology]] end to end — this now gates whether any further quality work (reranker, embedding swap, chunking rework) is justified, and gates whether Phase 3/4 work proceeds on top of a system with proven answer quality.
 
 ## 📐 How the work packages are written
 

--- a/DOCS/audit/04-Scalability-Plan.md
+++ b/DOCS/audit/04-Scalability-Plan.md
@@ -125,7 +125,7 @@ related:
 **Directions:**
 - Parallelize the per-doc `search-by-doc` loop (`service.py:183-200`) with `asyncio.gather` + semaphore(10).
 - Real tokenizer for the context budget (tiktoken or provider count) instead of `len(text.split())` (`service.py:271`).
-- Add a reranker stage (flag-gated): cross-encoder over top-50 → top-10 (runs in `rag_orchestrator`; model via [[06-LLM-Provider-LiteLLM-Plan|LiteLLM]] or local `bge-reranker`).
+- Add a reranker stage (flag-gated): cross-encoder over top-50 → top-10 (runs in `rag_orchestrator`; model via [[06-LLM-Provider-LiteLLM-Plan|LiteLLM]] or local `bge-reranker`). **Gate:** only build this after [[08-RAG-Quality-Evaluation-Methodology]] shows correct chunks landing at rank 8–20, not absent or already top-3.
 - Cap and dedupe expanded context (today `max_total_chunks=9999`, `service.py:262`).
 **Acceptance criteria:**
 - [ ] Expanded-doc fetch is concurrent (test: 20 docs fetched in ~1 RTT, not 20)

--- a/DOCS/audit/07-Roadmap.md
+++ b/DOCS/audit/07-Roadmap.md
@@ -21,32 +21,56 @@ related:
 ## Phase 1 — Fix the foundation (1–2 weeks)
 *Theme: the graph tells the truth, and ingestion doesn't melt.*
 
-- [ ] [[02-Graph-Depth-Analysis#WP-G1 — Async functions + richer metadata|WP-G1]] Async functions + metadata + rstrip bug (fixes F-01, F-05)
-- [ ] [[01-Codebase-Audit-Findings#F-12 · Graph traversal starts from ONE arbitrary seed|F-12]] Multi-seed traversal (one-liner class of fix, big quality win)
-- [ ] [[04-Scalability-Plan#WP-S1 — Make graph build O(N)|WP-S1]] O(N) graph build + ignore semantics + benchmark harness
-- [ ] [[04-Scalability-Plan#WP-S2 — Batch embedding + persistence|WP-S2]] Batch embedding/persistence, kill dual-write
-- [ ] [[04-Scalability-Plan#WP-S3 — Transactional, bulk graph persistence|WP-S3]] Atomic bulk persistence + per-repo lock
-- [ ] [[04-Scalability-Plan#WP-S4 — ANN index + query-path hygiene|WP-S4]] HNSW index + real filter columns
-- [ ] [[05-Enterprise-Platform-Plan#WP-E2 — Deployability images, config, CI|WP-E2 (CI part)]] Working CI (F-17) — do early so all later WPs land gated
+- [x] [[02-Graph-Depth-Analysis#WP-G1 — Async functions + richer metadata|WP-G1]] Async functions + metadata + rstrip bug (fixes F-01, F-05)
+- [x] [[01-Codebase-Audit-Findings#F-12 · Graph traversal starts from ONE arbitrary seed|F-12]] Multi-seed traversal (one-liner class of fix, big quality win)
+- [x] [[04-Scalability-Plan#WP-S1 — Make graph build O(N)|WP-S1]] O(N) graph build + ignore semantics + benchmark harness
+- [x] [[04-Scalability-Plan#WP-S2 — Batch embedding + persistence|WP-S2]] Batch embedding/persistence, kill dual-write
+- [x] [[04-Scalability-Plan#WP-S3 — Transactional, bulk graph persistence|WP-S3]] Atomic bulk persistence + per-repo lock
+- [x] [[04-Scalability-Plan#WP-S4 — ANN index + query-path hygiene|WP-S4]] HNSW index + real filter columns (typed filter columns landed later as WP-S4B)
+- [x] [[05-Enterprise-Platform-Plan#WP-E2 — Deployability images, config, CI|WP-E2 (CI part)]] Working CI (F-17) — do early so all later WPs land gated
 
-**Exit criteria:** benchmark repo (2k files) ingests < 2 min; vector search uses index; CI green on every PR.
+**Exit criteria:** benchmark repo (2k files) ingests < 2 min; vector search uses index; CI green on every PR. **Met** — see `DOCS/test_results/Phase-1-Exit-Report.md`.
 
 ## Phase 2 — Graph depth + LLM freedom (2–3 weeks, two parallel tracks)
 *Theme: answers get materially better.*
 
 **Track A — graph (sequential):**
-- [ ] [[02-Graph-Depth-Analysis#WP-G3 — Remove CALL nodes from identity space; keep call sites as evidence|WP-G3]] Call-site model fix (F-03)
-- [ ] [[02-Graph-Depth-Analysis#WP-G2 — Materialize `IMPORTS` edges|WP-G2]] IMPORTS edges (F-02)
-- [ ] [[02-Graph-Depth-Analysis#WP-G4 — Scope- and import-aware call resolution (implement ADR-032 fully)|WP-G4]] Real call resolution (F-04)
-- [ ] [[02-Graph-Depth-Analysis#WP-G5 — `INHERITS` and `OVERRIDES` edges|WP-G5]] Inheritance edges
-- [ ] [[02-Graph-Depth-Analysis#WP-G6 — Traversal layer catches up with the deeper graph|WP-G6]] Traversal strategies catch up
+- [x] [[02-Graph-Depth-Analysis#WP-G3 — Remove CALL nodes from identity space; keep call sites as evidence|WP-G3]] Call-site model fix (F-03)
+- [x] [[02-Graph-Depth-Analysis#WP-G2 — Materialize `IMPORTS` edges|WP-G2]] IMPORTS edges (F-02)
+- [x] [[02-Graph-Depth-Analysis#WP-G4 — Scope- and import-aware call resolution (implement ADR-032 fully)|WP-G4]] Real call resolution (F-04)
+- [x] [[02-Graph-Depth-Analysis#WP-G5 — `INHERITS` and `OVERRIDES` edges|WP-G5]] Inheritance edges
+- [x] [[02-Graph-Depth-Analysis#WP-G6 — Traversal layer catches up with the deeper graph|WP-G6]] Traversal strategies catch up
 
 **Track B — LLM (independent, small):**
-- [ ] [[06-LLM-Provider-LiteLLM-Plan#WP-M1 — LiteLLM core swap|WP-M1]] LiteLLM swap
-- [ ] [[06-LLM-Provider-LiteLLM-Plan#WP-M2 — Resilience fallbacks, retries, timeouts|WP-M2]] Fallbacks/retries
-- [ ] [[06-LLM-Provider-LiteLLM-Plan#WP-M5 — Model switching in the product surface|WP-M5]] Model picker
+- [x] [[06-LLM-Provider-LiteLLM-Plan#WP-M1 — LiteLLM core swap|WP-M1]] LiteLLM swap
+- [x] [[06-LLM-Provider-LiteLLM-Plan#WP-M2 — Resilience fallbacks, retries, timeouts|WP-M2]] Fallbacks/retries
+- [x] [[06-LLM-Provider-LiteLLM-Plan#WP-M5 — Model switching in the product surface|WP-M5]] Model picker
+- [x] *(beyond original scope)* Multi-endpoint routing shipped in PR #47 — env-activated Tailscale Ollama default with fallback chain; Groq/NVIDIA NIM first-class support tracked separately as issue #46
 
-**Exit criteria:** "what calls X" correct on eval fixtures incl. methods & cross-file; any cloud model usable by alias.
+**Exit criteria:** "what calls X" correct on eval fixtures incl. methods & cross-file; any cloud model usable by alias. **Met.**
+
+## Phase 2.5 — Live hardening (unplanned, reactive; shipped 2026-07-19/20)
+*Theme: bugs that only surfaced once the merged stack ran end-to-end in Docker.*
+
+- [x] Issue #30 (5 parts): repo_id dropped in the query path, caller routing, context caps, source labels, repo metadata
+- [x] PR #40: sources resolving to UUIDs instead of names (nested `metadata.source_metadata` bug)
+- [x] PR #42: fallback-chain timeout regression from the LiteLLM swap (503s on CPU Ollama)
+- [x] PR #47: multi-endpoint LiteLLM routing (Tailscale remote Ollama default + fallback)
+- [ ] Finish the remaining live-smoke-test acceptance items before starting Phase 3/4 work (tracked as issue #48):
+  - [ ] Subclass/override graph expansion firing correctly at low `top_k`
+  - [ ] Two-repository source isolation (no cross-repo leakage)
+  - [ ] Model-alias switching (default vs. explicit `ollama/...`, forced fallback via `model=smart`)
+  - [ ] Gradio UI visual pass (labels, model dropdown, model-used line)
+
+**Exit criteria:** the four remaining smoke-test items pass, closing out the acceptance pass for everything merged so far — this is a prerequisite for treating Phase 1/2 as done in practice, not just in code.
+
+## Phase 2.75 — RAG quality baseline (empirical, precedes any Phase 4 reranker work)
+*Theme: prove the system retrieves the right evidence and answers well before changing anything else.*
+
+- [ ] [[08-RAG-Quality-Evaluation-Methodology#0 · Recommended execution order (WP-Q0)|WP-Q0]] Build curated eval corpus + run the unified chunking/retrieval/generation pass, classify every failure (tracked as issue #49)
+- [ ] Reranker go/no-go decision recorded per [[08-RAG-Quality-Evaluation-Methodology#4 · Reranker decision gate|the decision gate]]
+
+**Exit criteria:** every eval-corpus failure is classified (chunking/retrieval/filtering/ranking/generation); `WP-S8`'s reranker sub-task in Phase 4 either proceeds with evidence or is explicitly deferred with a recorded reason.
 
 ## Phase 3 — Multi-language (4–6 weeks)
 *Theme: the headline feature.*
@@ -66,7 +90,7 @@ related:
 - [ ] [[04-Scalability-Plan#WP-S5 — Job queue for ingestion|WP-S5]] Job queue (arq + Redis)
 - [ ] [[04-Scalability-Plan#WP-S6 — Incremental ingestion (the massive-repo unlock)|WP-S6]] Incremental ingestion + snapshot lineage
 - [ ] [[04-Scalability-Plan#WP-S7 — Bounded graph service instead of whole-graph-in-RAM|WP-S7]] Traverse endpoint, kill whole-graph RAM cache
-- [ ] [[04-Scalability-Plan#WP-S8 — Retrieval quality/perf at scale|WP-S8]] Concurrent fetch, real tokenizer, reranker flag
+- [ ] [[04-Scalability-Plan#WP-S8 — Retrieval quality/perf at scale|WP-S8]] Concurrent fetch, real tokenizer, reranker flag (reranker sub-task gated on Phase 2.75's eval — see above)
 - [ ] [[05-Enterprise-Platform-Plan#WP-E1 — Security baseline (do first, small)|WP-E1]] Security baseline *(can and should be pulled earlier if anything is network-exposed)*
 - [ ] [[05-Enterprise-Platform-Plan#WP-E5 — Observability|WP-E5]] Observability
 - [ ] [[06-LLM-Provider-LiteLLM-Plan#WP-M3 — Streaming|WP-M3]] / [[06-LLM-Provider-LiteLLM-Plan#WP-M4 — Cost & usage telemetry|WP-M4]] Streaming + cost telemetry
@@ -89,11 +113,13 @@ related:
 
 ```mermaid
 graph LR
-  P1[Phase 1<br/>Foundation] --> P2A[Phase 2A<br/>Graph depth]
-  P1 --> P2B[Phase 2B<br/>LiteLLM]
-  P2A --> P3[Phase 3<br/>Multi-language]
-  P1 --> P4[Phase 4<br/>Scale + Ops]
-  P2B --> P4
+  P1[Phase 1<br/>Foundation ✅] --> P2A[Phase 2A<br/>Graph depth ✅]
+  P1 --> P2B[Phase 2B<br/>LiteLLM ✅]
+  P2A --> P25[Phase 2.5<br/>Live hardening]
+  P2B --> P25
+  P25 --> P275[Phase 2.75<br/>RAG quality baseline]
+  P275 --> P3[Phase 3<br/>Multi-language]
+  P275 --> P4[Phase 4<br/>Scale + Ops]
   P3 --> P5[Phase 5<br/>Enterprise]
   P4 --> P5
 ```
@@ -101,8 +127,10 @@ graph LR
 > [!warning] Two rules that keep this roadmap honest
 > 1. **Nothing ships without its benchmark/eval delta recorded** (`DOCS/test_results/`). Phase 1 builds the harness; every later WP reports against it.
 > 2. **Graph-depth work after Phase 2 goes through the IR** ([[03-Multi-Language-Graph-Plan]]) — no more Python-only resolution code once WP-L1 lands.
+> 3. **Phase 4's reranker sub-task (`WP-S8`) does not start until Phase 2.75 proves it's the actual bottleneck** — see [[08-RAG-Quality-Evaluation-Methodology]].
 
-> [!note] Suggested first three agent tasks (this week)
-> 1. WP-G1 + F-05 + F-12 in one PR (small, high-value, builds trust in the loop)
-> 2. WP-S1 with the benchmark fixture generator
-> 3. CI rewrite (WP-E2 CI part) so tasks 1–2 land gated
+> [!note] Current next steps (2026-07-20)
+> 1. Finish the four remaining Phase 2.5 smoke-test items (tracked in the issue register).
+> 2. Run Phase 2.75's `WP-Q0` eval pass and record a reranker go/no-go decision.
+> 3. Only then resume Phase 3/4 work.
+

--- a/DOCS/audit/08-RAG-Quality-Evaluation-Methodology.md
+++ b/DOCS/audit/08-RAG-Quality-Evaluation-Methodology.md
@@ -1,0 +1,213 @@
+---
+title: "RAG Quality Evaluation Methodology — Chunking → Retrieval → Generation → Reranker Gate"
+date: 2026-07-20
+type: audit-methodology
+status: proposed
+issue: "#49 (Phase 2.5 acceptance pass is issue #48 and is a prerequisite)"
+tags:
+  - audit
+  - rag-quality
+  - evaluation
+  - rag-foundry
+related:
+  - "[[00-Audit-Overview]]"
+  - "[[04-Scalability-Plan]]"
+  - "[[../adr/ADR-039-artifact-level-embedding-strategy]]"
+  - "[[../adr/ADR-040-code-intelligence-embedding-strategy]]"
+  - "[[../adr/ADR-045-hybrid-vector-graph-rag]]"
+---
+
+# 🔬 RAG Quality Evaluation Methodology
+
+> [!abstract] Purpose
+> Before adding a reranker (or swapping the embedder, or tuning chunk sizes), verify the
+> foundations in order: **chunking → retrieval → generation**. This doc records that
+> methodology, maps each stage to the actual code in this repo, and gives a decision rule
+> for when — and only when — a reranker is justified. Nothing here has been executed yet;
+> this is the eval plan, not eval results. Results go in `DOCS/test_results/` per WP.
+
+## 🧭 The core rule
+
+> A reranker only helps when the correct chunk is already somewhere in the candidate set
+> but ranked too low. It **cannot** fix: missing content, broken chunk boundaries, wrong
+> repository filtering, poor embeddings, or incomplete ingestion.
+
+Diagnostic order — do not skip ahead:
+
+```text
+verify ingestion → inspect chunking → measure retrieval recall → test generation
+→ add reranking only if ranking is the proven bottleneck
+```
+
+Decision table once a known-answer query has been run:
+
+| Observation | Likely problem |
+|---|---|
+| Relevant evidence absent from the retrieved candidate set (top 20) | Chunking, embedding, filtering, query formulation, or retrieval — **not** a reranker problem |
+| Relevant evidence appears around rank 8–20 | Reranker may help |
+| Relevant evidence already in the top 3, but the answer is poor | Prompting, context assembly, or generation model — **not** a reranker problem |
+| Correct evidence retrieved, but from the wrong repository | Repo-isolation or metadata-filtering defect (ADR-030 correctness bug) |
+| Many near-identical chunks occupy the result set | Chunking overlap or deduplication problem |
+| Answer omits an important fact present in the supplied context | Generation or context-formatting problem |
+
+`WP-S8` in [[04-Scalability-Plan]] already stubs a flag-gated reranker with the
+acceptance criterion *"reranker flag on/off compared on a small eval set"* — this doc is
+the prerequisite work that produces that eval set and proves (or disproves) the need
+before WP-S8's reranker half is picked up.
+
+> [!tip] The most valuable outcome may be a negative result
+> If the eval below shows the reranker isn't the bottleneck, that's not a null result —
+> it means the system can still improve through chunking fixes, metadata filtering,
+> deduplication, traversal tuning, and prompt assembly, **without** adding another model,
+> another latency stage, or another operational dependency. Proving a reranker
+> unnecessary is cheaper than building one and finding out later.
+
+---
+
+## 0 · Recommended execution order (WP-Q0)
+
+The work is **empirical, not architectural** — this is one evaluation pass over a small
+curated corpus, not three independent audits. Do it in this order, in one pass per query:
+
+1. **Build a small, curated evaluation corpus** containing both code (an ingested repo)
+   and uploaded documents — reuse `shared/smoke_repo` (already a live-smoke fixture) plus
+   2–3 representative documents, so the corpus is real ingested data, not synthetic text.
+2. **Define answerable questions**, each with an exact expected source artifact
+   (`canonical_id` for code, a specific passage for documents) — 8–12 questions, mixing
+   code and document queries, per §2's known-answer-set guidance.
+3. **For every question, record all of the following in one row** (not just rank —
+   the full diagnostic surface in a single pass):
+
+   | Field | What it tells you |
+   |---|---|
+   | Source present in index | Ingestion actually succeeded for this artifact — if false, stop here, it's an ingestion bug, not a retrieval or reranker question |
+   | Seed rank (top-k vector search) | Where §2's decision table starts |
+   | Expanded-context rank (after graph traversal) | Whether graph expansion recovers a seed miss |
+   | Duplicates in candidate set | Whether redundant chunks are crowding the window (§2) |
+   | Repository leakage | Whether `repo_id` scoping actually held (ADR-030 correctness bug if not) |
+   | Final answer quality | Pass/fail against the expected passage, using the *actual* end-to-end path (not clean context yet) |
+
+4. **Run the clean-context generation test (§3) for every failed answer only** — not
+   for every question. If the answer already passed end-to-end, there's nothing to
+   isolate.
+5. **Classify every failure** using the decision table before changing anything:
+   absent from top 20 (chunking/retrieval/filtering problem) vs. rank 8–20 (reranker
+   candidate) vs. top-3-but-bad-answer (prompting/model problem). Do not touch chunking,
+   retrieval, or the generator until this classification is done for the whole corpus.
+6. **Only after classification**, change chunking or retrieval to fix whatever the
+   dominant failure class actually is.
+7. **Consider a reranker only if** enough failures consistently classify into the rank
+   8–20 bucket — "enough" meaning a real fraction of the corpus, not one query's
+   coincidence.
+
+**Acceptance criteria (WP-Q0):**
+- [ ] Curated corpus assembled (repo + documents) and committed or referenced (e.g. `shared/smoke_repo`)
+- [ ] 8–12 answerable questions defined with exact expected source artifact/passage
+- [ ] One recording table (the six fields above) filled in per question, in `DOCS/test_results/`
+- [ ] Clean-context test (§3) run for every failed answer, not every question
+- [ ] Every failure classified per the decision table before any chunking/retrieval change is made
+- [ ] Explicit go/no-go verdict recorded on the reranker, with the failure-count breakdown that justifies it
+
+Sections 1–3 below give the background and per-stage detail (why chunking looks the way
+it does today, what "seed rank" and "expanded rank" mean concretely, how the clean-context
+test is scored) for executing steps 1–4 above; they are reference, not a second pass.
+
+---
+
+## 1 · Chunking quality
+
+**What exists today** (read before assuming a generic "chunking problem"):
+
+- Code artifacts do **not** go through a text chunker at all. Per [[../adr/ADR-039-artifact-level-embedding-strategy|ADR-039]] / [[../adr/ADR-040-code-intelligence-embedding-strategy|ADR-040]], the *artifact is the embedding unit* — a MODULE embeds the whole file, a CLASS/FUNCTION/METHOD embeds its whole def block (`RepoGraphBuilder` via `ast.get_source_segment`). There is no chunk-boundary question for code today because there are no sub-artifact chunks.
+- Plain documents and uploaded files go through `shared/chunkers/text.py` (`TextChunker`) via `shared/chunkers/selector.py` (`ChunkerFactory.choose_strategy`), which picks a strategy **purely from content length**, not structure:
+  - `< 2000` chars → `sentence`, `chunk_size=200, overlap=20`
+  - `< 10000` chars → `paragraph`, `chunk_size=500, overlap=50`
+  - `>= 10000` chars → `fixed_char`, `chunk_size=1000, overlap=100`
+  - This heuristic has no awareness of Markdown headings, fenced code blocks, or table boundaries — a fenced code block or heading can be split mid-block if it straddles a `chunk_size` boundary.
+- Docling/OCR ingestion (ADR-047) sits in front of this for documents — check whether Docling's own structural chunking is used, or whether Docling output is re-chunked by `TextChunker` (would be a double-chunking bug if so).
+
+**Questions to answer:**
+
+- Are chunks semantically coherent — does a chunk read as a complete thought when shown in isolation?
+- Are headings, code fences, and surrounding context preserved, or does a chunk boundary land mid-sentence / mid-code-block?
+- Are chunks too large (diluting embedding relevance with unrelated content) or too small (losing context needed to answer)?
+
+**How to check (manual, no new tooling required):**
+
+1. Pick 5–10 representative source documents already ingested (mix of long Markdown with code fences, and a large plain-text doc that hits the `fixed_char` branch).
+2. Pull their chunks via `GET /v1/chunks` (`ingestion_service`) or a direct read of `vector_chunks`.
+3. For each chunk, read it standalone and score: coherent / truncated mid-thought / structure broken (heading separated from its section, code fence split).
+4. Record pass/fail per chunk in `DOCS/test_results/`.
+
+**Acceptance criteria (WP-Q1):**
+- [ ] 5–10 documents' chunks manually reviewed and scored coherent/broken, results in `DOCS/test_results/`
+- [ ] At least one confirmed example of a heading- or code-fence-split chunk, or a documented finding that none occurred
+- [ ] Explicit note on whether Docling output is being re-chunked by `TextChunker` (double-chunking risk)
+
+---
+
+## 2 · Retrieval quality
+
+**What exists today:**
+
+- Seed vector search defaults to `k=5` (`vector_store_service/src/api/v1/vectors.py:33`), filtered to `doc_type="code"` for the graph-aware path (ADR-045). `EXPANDED_DOC_CHUNKS=3` chunks are pulled per graph-expanded doc, capped at `MAX_EXPANDED_DOCS=20` and `MAX_TOTAL_CHUNKS=50` overall (`rag_orchestrator/src/core/config.py`).
+- Embeddings are `mxbai-embed-large:latest` (1024-dim) via Ollama (`rag_orchestrator/src/core/config.py`, `vector_store_service/src/core/config.py`).
+- Repo scoping is supposed to be a hard filter (ADR-030) — every query is scoped by `repo_id`, so cross-repo leakage in results would be a correctness bug, not a tuning issue.
+
+**Questions to answer:**
+
+- For a known question with a known correct chunk, does that chunk appear in the initial top 5 (seed vector search) or top 10–20 (after graph expansion)?
+- Are results actually restricted to the queried repo, or does another repo's content leak in?
+- Are near-duplicate chunks (e.g. the same function embedded twice from a stale re-ingest, or overlapping chunk windows) crowding out distinct useful matches?
+
+**How to check:**
+
+1. Build a small known-answer set: 8–12 (question, expected `canonical_id` or expected chunk substring, `repo_id`) tuples covering both code and document queries.
+2. For each, call `/v1/vectors/search` (or the orchestrator's retrieval path) directly and record the rank position of the expected chunk (absent / 1–5 / 6–10 / 11–20 / not found in 20).
+3. Cross-repo check: run the same query against a `repo_id` that should *not* contain the answer and confirm zero relevant hits.
+4. Duplicate check: scan the top-20 for near-identical `chunk_text` and note how many distinct *useful* chunks are actually present versus redundant repeats.
+5. Apply the decision table above per query.
+
+**Acceptance criteria (WP-Q2):**
+- [ ] Known-answer eval set (8–12 queries) checked in under `DOCS/test_results/`, with rank position recorded per query
+- [ ] Recall@5 and Recall@20 computed and reported
+- [ ] Cross-repo isolation confirmed (zero leakage) or filed as a bug if violated
+- [ ] Duplicate/near-duplicate rate in top-20 reported
+
+---
+
+## 3 · Answer quality with clean context
+
+**Goal:** isolate the generator from retrieval noise — hand-pick the best 2–4 chunks for a known query and judge the LLM's answer on its own merits.
+
+**Procedure:**
+
+1. For each known-answer query from §2, manually select the 2–4 best chunks (skip retrieval entirely — this step assumes retrieval already found the right chunk, per the decision table's "top 3, answer is poor" branch).
+2. Call the model directly (bypassing the LiteLLM-routed `/generate` service is fine for this diagnostic) — e.g. Ollama's `/api/chat` with `think:false` against `Qwen3` — with only those chunks as context.
+3. Score: grounding (does the answer only assert what's in context?), citation (does it point back to the right file/symbol?), omission (did it miss something present in the context?), latency.
+
+**Acceptance criteria (WP-Q3):**
+- [ ] 8–12 clean-context generations scored for grounding/citation/omission, recorded in `DOCS/test_results/`
+- [ ] Latency recorded per generation (cold and warm) for the model actually in use
+- [ ] Explicit verdict per query: prompting/model problem vs. no problem found
+
+---
+
+## 4 · Reranker decision gate
+
+Do not start reranker work (the reranker half of `WP-S8` in [[04-Scalability-Plan]]) until
+WP-Q0's recording table (§0) shows:
+
+- [ ] A non-trivial fraction of the corpus's questions have the correct chunk landing at rank 8–20 (not absent, not already top-3)
+- [ ] Those same failures are not already explained by a chunking defect (§1) or a generation defect confirmed via clean-context (§3)
+
+If the eval set instead shows "correct chunk absent from top 20" as the dominant failure mode, the next work is chunking/embedding/filtering fixes (§1/§2), not a reranker. If it shows "top 3 but bad answer," the next work is prompting or model choice (§3), not a reranker. If neither dominant pattern holds, record the negative result — see the callout in §0 — and move on to whichever lever (chunking, metadata filtering, dedup, traversal, prompt assembly) the corpus actually points to.
+
+---
+
+## Related
+
+- [[04-Scalability-Plan#WP-S8 — Retrieval quality/perf at scale|WP-S8]] — where the reranker itself would land, flag-gated, once this doc's gate is satisfied
+- [[../adr/ADR-045-hybrid-vector-graph-rag|ADR-045]] — the retrieval flow being evaluated
+- [[../adr/ADR-039-artifact-level-embedding-strategy|ADR-039]] / [[../adr/ADR-040-code-intelligence-embedding-strategy|ADR-040]] — why code has no chunk-boundary question today
+- `DOCS/test_results/` — where every WP above must record its eval output, per the roadmap's "nothing ships without its benchmark/eval delta recorded" rule


### PR DESCRIPTION
## Summary
- Adds `DOCS/audit/08-RAG-Quality-Evaluation-Methodology.md`: the chunking -> retrieval -> generation eval order and the reranker decision gate (don't build WP-S8's reranker until an eval proves rank 8-20 is the actual bottleneck).
- Reconciles `DOCS/audit/07-Roadmap.md` and `DOCS/audit/00-Audit-Overview.md` with what's actually shipped — Phase 1/2 checkboxes were stale (unchecked) despite the work being merged; adds Phase 2.5 (live hardening: issue #30, PR #40/#42/#47) and Phase 2.75 (RAG quality baseline) between Phase 2 and Phase 3.
- Cross-links `04-Scalability-Plan.md`'s WP-S8 reranker sub-task to the new gate.

Closes/tracks issues #48 and #49.

## Test plan
- [ ] Docs only — no code changes, nothing to run
- [ ] Obsidian-style `[[wikilinks]]` resolve correctly within `DOCS/audit/`