### PR TITLE
Fix graph expansion for module/class-level seeds (issue #48)

### DIFF
--- a/rag_orchestrator/src/retrieval/traversal_selector.py
+++ b/rag_orchestrator/src/retrieval/traversal_selector.py
@@ -146,28 +146,46 @@ def select_traversal_strategies(
     )
     return strategies
 
+def _seed_and_defines_descendants(graph: CodebaseGraph, start_cid: str) -> List[str]:
+    """INHERITS/OVERRIDES/CALL edges live on CLASS/METHOD nodes, never on
+    the enclosing MODULE. Vector search often seeds the coarser MODULE
+    (or CLASS, for a method-level edge) artifact instead of the exact
+    symbol, which otherwise makes those traversal strategies silently
+    return nothing even though the edge exists one DEFINES hop away.
+    Expand the anchor set to the seed plus everything it (transitively)
+    defines, so class/method-scoped strategies still find it."""
+    if graph is None:
+        return [start_cid]
+    descendants = traverse_defines(graph, start_cid, depth=2)
+    return [start_cid] + [n.canonical_id for n in descendants]
+
+
 def execute_traversals(
     graph: CodebaseGraph,
     start_canonical_id: str,
     strategies: List[Callable[[CodebaseGraph, str], List[Node]]]
 ) -> List[Node]:
     """
-    Execute all selected traversal strategies.
+    Execute all selected traversal strategies from the seed and its
+    DEFINES descendants (see `_seed_and_defines_descendants`).
     """
     all_expanded_nodes = []
+    anchors = _seed_and_defines_descendants(graph, start_canonical_id)
 
     for strategy in strategies:
-        try:
-            nodes = strategy(graph, start_canonical_id)
-            all_expanded_nodes.extend(nodes)
-            logger.debug(
-                f"Strategy returned {len(nodes)} nodes from {start_canonical_id}"
-            )
-        except Exception as e:
-            logger.warning(f"Traversal strategy failed: {e}")
-            continue
+        for anchor in anchors:
+            try:
+                nodes = strategy(graph, anchor)
+                all_expanded_nodes.extend(nodes)
+                logger.debug(f"Strategy returned {len(nodes)} nodes from {anchor}")
+            except Exception as e:
+                logger.warning(f"Traversal strategy failed: {e}")
+                continue
 
-    # Deduplicate by canonical_id
+    # Deduplicate by canonical_id. A DEFINES descendant used purely as an
+    # extra anchor (e.g. Dog.speak when the seed was Dog) can legitimately
+    # also be the answer itself for a "structure" query, so anchors are
+    # not excluded here — only the true seed is, by the caller.
     unique_nodes = {node.canonical_id: node for node in all_expanded_nodes}.values()
     logger.info(f"Total unique expanded nodes: {len(unique_nodes)}")
     return list(unique_nodes)

--- a/rag_orchestrator/tests/test_inheritance_traversal.py
+++ b/rag_orchestrator/tests/test_inheritance_traversal.py
@@ -75,3 +75,65 @@ def test_what_subclasses_calculator_end_to_end(graph):
     strategies = select_traversal_strategies("what subclasses Calculator", seeds)
     nodes = execute_traversals_from_seeds(graph, seeds, strategies)
     assert "sci.py#Scientific" in cids(nodes)
+
+
+@pytest.fixture()
+def graph_with_modules():
+    """Same hierarchy as `graph`, but with MODULE nodes DEFINES-linked to
+    their classes/methods — mirrors the real ingested graph shape, where
+    INHERITS/OVERRIDES edges live on CLASS/METHOD nodes while vector
+    search often seeds the coarser MODULE artifact instead (issue #48)."""
+    g = CodebaseGraph()
+    for cid, path in [
+        ("calc.py", "calc.py"),
+        ("calc.py#Calculator", "calc.py"),
+        ("calc.py#Calculator.compute", "calc.py"),
+        ("sci.py", "sci.py"),
+        ("sci.py#Scientific", "sci.py"),
+        ("sci.py#Scientific.compute", "sci.py"),
+    ]:
+        g.add_node(Node(cid, path))
+
+    g.add_edge("calc.py", "calc.py#Calculator", "DEFINES")
+    g.add_edge("calc.py#Calculator", "calc.py#Calculator.compute", "DEFINES")
+    g.add_edge("sci.py", "sci.py#Scientific", "DEFINES")
+    g.add_edge("sci.py#Scientific", "sci.py#Scientific.compute", "DEFINES")
+    g.add_edge("sci.py#Scientific", "calc.py#Calculator", "INHERITS")
+    g.add_edge(
+        "sci.py#Scientific.compute", "calc.py#Calculator.compute", "OVERRIDES"
+    )
+    return g
+
+
+def test_module_level_seed_still_finds_subclasses(graph_with_modules):
+    """issue #48 regression: at low top_k, vector search can seed the
+    MODULE (calc.py) rather than the CLASS (calc.py#Calculator). Before
+    the fix, traversal ran BFS from calc.py itself, which has no INHERITS
+    edge, so 'what subclasses Calculator' silently returned nothing even
+    though sci.py#Scientific inherits from it."""
+    seeds = {"calc.py"}
+    strategies = select_traversal_strategies("what subclasses Calculator", seeds)
+    nodes = execute_traversals_from_seeds(graph_with_modules, seeds, strategies)
+    assert "sci.py#Scientific" in cids(nodes)
+
+
+def test_class_level_seed_still_finds_method_overrides(graph_with_modules):
+    """Same gap one level down: seeding the CLASS (sci.py#Scientific)
+    rather than the METHOD (sci.py#Scientific.compute) must still surface
+    the OVERRIDES edge that lives on the method."""
+    seeds = {"sci.py#Scientific"}
+    strategies = select_traversal_strategies(
+        "which methods are overridden in Scientific", seeds
+    )
+    nodes = execute_traversals_from_seeds(graph_with_modules, seeds, strategies)
+    assert "calc.py#Calculator.compute" in cids(nodes)
+
+
+def test_module_seed_structure_query_unaffected(graph_with_modules):
+    """The anchor expansion must not make a seed's own DEFINES children
+    disappear from a 'structure' query's results — those children ARE
+    the expected answer for 'what does calc.py define'."""
+    seeds = {"calc.py"}
+    strategies = select_traversal_strategies("what classes are defined in calc.py", seeds)
+    nodes = execute_traversals_from_seeds(graph_with_modules, seeds, strategies)
+    assert "calc.py#Calculator" in cids(nodes)


### PR DESCRIPTION
## Summary
- Closes the "subclass/override expansion at low `top_k`" item of #48.
- Live-verified against `shared/smoke_repo`: at `top_k=1`, "what subclasses Animal?" seeded on the `animals.py` module (not the `Animal` class), so `traverse_subclasses`' BFS found no `INHERITS` edge and the answer wrongly claimed no subclasses exist. Same gap for "which methods are overridden in Dog?" (seed was the `Dog` class, edge lives on `Dog.speak`).
- Fix: `execute_traversals` now runs each strategy from the seed **and** everything it transitively `DEFINES`, so a coarser seed still reaches the symbol the edge lives on. Verified this doesn't regress "structure" (`defines`) queries, since anchors aren't excluded from results — only the original seed already was, upstream.
- 3 new regression tests in `test_inheritance_traversal.py` (module-seed subclass, class-seed override, structure-query non-regression). Full `rag_orchestrator` unit suite: 72/72 passing.
- Also re-verified two-repo isolation and model-alias switching/fallback (both already correct, no code changes needed) against the live Docker stack with the remote Tailscale Ollama endpoint.

Side findings surfaced while testing (not fixed here, reporting separately): `docker compose restart` doesn't pick up code edits for `ingestion_service`/`llm_service`/`rag_orchestrator` because their Dockerfile `CMD` runs from a build-time-baked copy rather than the bind-mounted dev path — a rebuild is required. Confirmed issue #41 (runtime uv/torch download) reproduces on every rebuild.

## Test plan
- [x] `cd rag_orchestrator && ../.venv/Scripts/python.exe -m pytest -m unit -q` — 72 passed
- [x] Live: `what subclasses Animal?` and `which methods are overridden in Dog?` against `shared/smoke_repo` at `top_k=1` — both now return correct answers with real graph expansion
- [x] Live: caller query ("what functions call train_dog?") unaffected
- [x] Live: two-repo isolation (smoke_repo vs TradeForge) — no cross-repo leakage
- [x] Live: model-alias switching (default/explicit/remote-endpoint/forced-fallback) — all correct