### PR TITLE
Fix dev bind mounts so restart picks up code edits (#52)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,12 +86,12 @@ services:
     ports:
       - "8003:8000"
     volumes:
-      - ./llm_service:/app/src
+      - ./llm_service/src:/app/llm_service/src
       - ./shared:/app/shared
     env_file:
       - ./.env
     environment:
-      PYTHONPATH: /app:/app/src
+      PYTHONPATH: /app:/app/llm_service
     healthcheck:
       test: ["CMD-SHELL", "python3", "-c", "import requests; exit(0) if requests.get('http://localhost:8003/health').status_code==200 else exit(1)"]
       interval: 5s
@@ -111,12 +111,12 @@ services:
     ports:
       - "8004:8000"
     volumes:
-      - ./rag_orchestrator:/app/src
+      - ./rag_orchestrator/src:/app/rag_orchestrator/src
       - ./shared:/app/shared
     env_file:
       - ./.env
     environment:
-      PYTHONPATH: /app:/app/src
+      PYTHONPATH: /app:/app/rag_orchestrator
     networks:
       - ragnet
     depends_on:


### PR DESCRIPTION
## Summary
- `llm_service` and `rag_orchestrator` bind-mounted the host directory to `/app/src`, but each service's Dockerfile `CMD` runs `uv run --directory /app/<service> uvicorn src.api.v1.main:app` — a different path entirely — so no bind-mounted edit was ever visible to the running server without a full `docker compose up -d --build`.
- Repoints each mount (and its `PYTHONPATH`) at the `src/` subdirectory under `/app/<service>`, the exact path `CMD` reads from — matching the pattern `ingestion_service` already uses successfully.
- `vector_store_service` and `ingestion_service` needed no change; their mounts already targeted paths `CMD` reads from.

An earlier attempt mounted the whole service directory (mirroring `vector_store_service`'s pattern) but that pulls each service's own host-side `.venv` into the container, causing `uv run --directory ...` to detect a foreign-platform venv and re-sync/re-download the full torch/CUDA dependency set (~2GB) on every container recreate. Scoping the mount to `src/` only avoids that regression while still fixing the live-edit issue.

Closes #52.

## Test plan
- [x] `docker compose up --build` — all four affected services (`ingestion_service`, `vector_store_service`, `llm_service`, `rag_orchestrator`) start healthy.
- [x] Edited `rag_orchestrator/src/api/v1/main.py`'s `/health` handler, ran `docker compose restart rag_orchestrator` (no rebuild) — response reflected the edit.
- [x] Repeated for `llm_service` — same result.
- [x] Confirmed a plain `restart` (not recreate) completes in ~7s with no dependency re-download, since `src/`-only mounting leaves each service's baked `.venv` untouched.